### PR TITLE
performance fix: broadcasts are async  …

### DIFF
--- a/rpc/events.go
+++ b/rpc/events.go
@@ -1,0 +1,13 @@
+package rpc
+
+import (
+	protocol "github.com/keybase/gregor/protocol/go"
+)
+
+type eventHandler interface {
+	connectionCreated(protocol.UID)
+	connectionDestroyed(protocol.UID)
+	uidServerCreated(protocol.UID)
+	uidServerDestroyed(protocol.UID)
+	broadcastSent(protocol.Message)
+}

--- a/rpc/events_test.go
+++ b/rpc/events_test.go
@@ -1,0 +1,48 @@
+package rpc
+
+import (
+	protocol "github.com/keybase/gregor/protocol/go"
+)
+
+// events is a type used to track various events in the gregor rpc
+// system.  Currently for testing purposes only.
+//
+// The addEvent* functions below are meant to be noops except when
+// newEvents() is called at the beginning of a test.
+type events struct {
+	connCreated     chan protocol.UID
+	connDestroyed   chan protocol.UID
+	perUIDCreated   chan protocol.UID
+	perUIDDestroyed chan protocol.UID
+	bcastSent       chan protocol.Message
+}
+
+func newEvents() *events {
+	return &events{
+		connCreated:     make(chan protocol.UID, 100),
+		connDestroyed:   make(chan protocol.UID, 100),
+		perUIDCreated:   make(chan protocol.UID, 100),
+		perUIDDestroyed: make(chan protocol.UID, 100),
+		bcastSent:       make(chan protocol.Message, 100),
+	}
+}
+
+func (e *events) connectionCreated(uid protocol.UID) {
+	e.connCreated <- uid
+}
+
+func (e *events) connectionDestroyed(uid protocol.UID) {
+	e.connDestroyed <- uid
+}
+
+func (e *events) uidServerCreated(uid protocol.UID) {
+	e.perUIDCreated <- uid
+}
+
+func (e *events) uidServerDestroyed(uid protocol.UID) {
+	e.perUIDDestroyed <- uid
+}
+
+func (e *events) broadcastSent(m protocol.Message) {
+	e.bcastSent <- m
+}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -3,7 +3,6 @@ package rpc
 import (
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"log"
 	"net"
 
@@ -100,8 +99,6 @@ func (s *Server) getPerUIDServer(u gregor.UID) (*perUIDServer, error) {
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("A\n")
-	fmt.Printf("B\n")
 	ret := s.users[k]
 	if ret != nil {
 		return ret, nil
@@ -198,9 +195,7 @@ func (s *Server) BroadcastMessage(c context.Context, m gregor.Message) error {
 }
 
 func (s *Server) sendBroadcast(c context.Context, m protocol.Message) error {
-	fmt.Printf("Q1\n")
 	srv, err := s.getPerUIDServer(gregor.UIDFromMessage(m))
-	fmt.Printf("Q2\n")
 	if err != nil {
 		return err
 	}
@@ -230,13 +225,9 @@ func (s *Server) serve() error {
 		case a := <-s.broadcastCh:
 			s.sendBroadcast(a.c, a.m)
 		case c := <-s.statsCh:
-			fmt.Printf("Z20.1\n")
 			s.reportStats(c)
-			fmt.Printf("Z20.2\n")
 		case a := <-s.confirmCh:
-			fmt.Printf("Z10\n")
 			s.confirmUIDShutdown(a)
-			fmt.Printf("Z10.1\n")
 		case <-s.closeCh:
 			return nil
 		}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -199,6 +199,11 @@ func (s *Server) sendBroadcast(c context.Context, m protocol.Message) error {
 	}
 	// Nothing to do...
 	if srv == nil {
+		// even though nothing to do, create an event if
+		// an event handler in place:
+		if s.events != nil {
+			s.events.broadcastSent(m)
+		}
 		return nil
 	}
 	srv.sendBroadcastCh <- messageArgs{c, m, nil}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -25,6 +25,12 @@ type messageArgs struct {
 	retCh chan<- error
 }
 
+// broadcastsSent will contain each messages that is sent to a
+// perUIDServer.  If it is nil (default), it won't be used.  But
+// tests can create a channel to figure out when async broadcasts
+// are sent.
+var broadcastsSent chan protocol.Message
+
 type confirmUIDShutdownArgs struct {
 	uid        protocol.UID
 	lastConnID connectionID

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -156,12 +156,10 @@ func (s *Server) confirmUIDShutdown(a confirmUIDShutdownArgs) {
 		delete(s.users, k)
 		delete(s.lastConns, k)
 
-		// Non-blocking send that it should self-destruct
+		// close perUser's selfShutdown channel so it will
+		// self-destruct
 		if su != nil {
-			select {
-			case su.shutdownCh <- struct{}{}:
-			default:
-			}
+			close(su.selfShutdownCh)
 		}
 
 		return

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -326,6 +326,9 @@ func TestCloseConnect2(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	<-ev.connCreated
+	<-ev.perUIDCreated
+
 	// close the first connection
 	c1.Shutdown()
 
@@ -336,14 +339,14 @@ func TestCloseConnect2(t *testing.T) {
 		t.Logf("broadcast error: %s", err)
 	}
 
+	<-ev.perUIDDestroyed
+
 	c2 := newClient(l.Addr())
 	defer c2.Shutdown()
 	if err := c2.AuthClient().Authenticate(context.TODO(), goodToken); err != nil {
 		t.Fatal(err)
 	}
 
-	// wait for two connection created events
-	<-ev.connCreated
 	<-ev.connCreated
 
 	// the user server should exist due to c2:

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -216,11 +216,14 @@ func TestCloseOne(t *testing.T) {
 	defer l.Close()
 	defer s.Shutdown()
 
+	fmt.Printf("X1\n")
 	c := newClient(l.Addr())
+	fmt.Printf("X2\n")
 
 	if err := c.AuthClient().Authenticate(context.TODO(), goodToken); err != nil {
 		t.Fatal(err)
 	}
+	fmt.Printf("X3\n")
 
 	ch := make(chan *Stats)
 	s.statsCh <- ch
@@ -229,7 +232,9 @@ func TestCloseOne(t *testing.T) {
 		t.Errorf("user servers: %d, expected 1", stats.UserServerCount)
 	}
 
+	fmt.Printf("X4\n")
 	c.Shutdown()
+	fmt.Printf("X5\n")
 
 	// broadcast a message to goodUID
 	m := newOOBMessage(goodUID, "sys", nil)
@@ -238,14 +243,17 @@ func TestCloseOne(t *testing.T) {
 		t.Logf("broadcast error: %s", err)
 	}
 
+	fmt.Printf("X6\n")
 	// make sure it didn't receive the broadcast
 	if len(c.broadcasts) != 0 {
 		t.Errorf("c broadcasts: %d, expected 0", len(c.broadcasts))
 	}
 
+	fmt.Printf("X7\n")
 	// and the user server should be deleted:
 	s.statsCh <- ch
 	stats = <-ch
+	fmt.Printf("X8\n")
 	if stats.UserServerCount != 0 {
 		t.Errorf("user servers: %d, expected 0", stats.UserServerCount)
 	}

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -170,6 +170,13 @@ func newUpdateMessage(uid protocol.UID) protocol.Message {
 }
 
 func TestBroadcast(t *testing.T) {
+	// create this channel so we can figure out when the async
+	// broadcast is complete.  Destroy it when the test is finished.
+	broadcastsSent = make(chan protocol.Message, 100)
+	defer func() {
+		broadcastsSent = nil
+	}()
+
 	s, l := startTestServer(nil)
 	defer l.Close()
 	defer s.Shutdown()
@@ -184,6 +191,9 @@ func TestBroadcast(t *testing.T) {
 	if err := s.BroadcastMessage(context.TODO(), m); err != nil {
 		t.Fatal(err)
 	}
+
+	// wait for the broadcast to be sent
+	<-broadcastsSent
 
 	if len(c.broadcasts) != 1 {
 		t.Errorf("client broadcasts received: %d, expected 1", len(c.broadcasts))
@@ -212,6 +222,13 @@ func TestConsume(t *testing.T) {
 }
 
 func TestCloseOne(t *testing.T) {
+	// create this channel so we can figure out when the async
+	// broadcast is complete.  Destroy it when the test is finished.
+	broadcastsSent = make(chan protocol.Message, 100)
+	defer func() {
+		broadcastsSent = nil
+	}()
+
 	s, l := startTestServer(nil)
 	defer l.Close()
 	defer s.Shutdown()
@@ -243,6 +260,9 @@ func TestCloseOne(t *testing.T) {
 		t.Logf("broadcast error: %s", err)
 	}
 
+	// wait for the message to be broadcast
+	<-broadcastsSent
+
 	fmt.Printf("X6\n")
 	// make sure it didn't receive the broadcast
 	if len(c.broadcasts) != 0 {
@@ -260,6 +280,13 @@ func TestCloseOne(t *testing.T) {
 }
 
 func TestCloseConnect(t *testing.T) {
+	// create this channel so we can figure out when the async
+	// broadcast is complete.  Destroy it when the test is finished.
+	broadcastsSent = make(chan protocol.Message, 100)
+	defer func() {
+		broadcastsSent = nil
+	}()
+
 	s, l := startTestServer(nil)
 	defer l.Close()
 	defer s.Shutdown()
@@ -284,6 +311,9 @@ func TestCloseConnect(t *testing.T) {
 		t.Logf("broadcast error: %s", err)
 	}
 
+	// wait for the broadcast to be sent
+	<-broadcastsSent
+
 	// the user server should still exist due to c2:
 	ch := make(chan *Stats)
 	s.statsCh <- ch
@@ -304,6 +334,13 @@ func TestCloseConnect(t *testing.T) {
 }
 
 func TestCloseConnect2(t *testing.T) {
+	// create this channel so we can figure out when the async
+	// broadcast is complete.  Destroy it when the test is finished.
+	broadcastsSent = make(chan protocol.Message, 100)
+	defer func() {
+		broadcastsSent = nil
+	}()
+
 	s, l := startTestServer(nil)
 	defer l.Close()
 	defer s.Shutdown()
@@ -322,6 +359,9 @@ func TestCloseConnect2(t *testing.T) {
 		// an error here is ok, as it could be about conn1 being closed:
 		t.Logf("broadcast error: %s", err)
 	}
+
+	// wait for the broadcast to be sent
+	<-broadcastsSent
 
 	c2 := newClient(l.Addr())
 	defer c2.Shutdown()

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -39,13 +39,15 @@ func (m *mockConsumer) ConsumeMessage(ctx context.Context, msg gregor.Message) e
 	return nil
 }
 
-func startTestServer(x gregor.NetworkInterfaceIncoming) (*Server, net.Listener) {
+func startTestServer(x gregor.NetworkInterfaceIncoming) (*Server, net.Listener, *events) {
+	ev := newEvents()
 	s := NewServer()
 	s.auth = mockAuth{}
+	s.events = ev
 	l := newLocalListener()
 	go s.Serve(x)
 	go s.ListenLoop(l)
-	return s, l
+	return s, l, ev
 }
 
 func newLocalListener() net.Listener {
@@ -111,7 +113,7 @@ func (c *client) BroadcastMessage(ctx context.Context, m protocol.Message) error
 }
 
 func TestAuthentication(t *testing.T) {
-	_, l := startTestServer(nil)
+	_, l, _ := startTestServer(nil)
 	defer l.Close()
 
 	c := newClient(l.Addr())
@@ -127,7 +129,7 @@ func TestAuthentication(t *testing.T) {
 }
 
 func TestCreatePerUIDServer(t *testing.T) {
-	s, l := startTestServer(nil)
+	s, l, ev := startTestServer(nil)
 	defer l.Close()
 	defer s.Shutdown()
 
@@ -137,6 +139,9 @@ func TestCreatePerUIDServer(t *testing.T) {
 	if err := c.AuthClient().Authenticate(context.TODO(), goodToken); err != nil {
 		t.Fatal(err)
 	}
+
+	// wait for events from above before checking state
+	<-ev.connCreated
 
 	ch := make(chan *Stats)
 	s.statsCh <- ch
@@ -170,14 +175,7 @@ func newUpdateMessage(uid protocol.UID) protocol.Message {
 }
 
 func TestBroadcast(t *testing.T) {
-	// create this channel so we can figure out when the async
-	// broadcast is complete.  Destroy it when the test is finished.
-	broadcastsSent = make(chan protocol.Message, 100)
-	defer func() {
-		broadcastsSent = nil
-	}()
-
-	s, l := startTestServer(nil)
+	s, l, ev := startTestServer(nil)
 	defer l.Close()
 	defer s.Shutdown()
 
@@ -187,13 +185,15 @@ func TestBroadcast(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	<-ev.connCreated
+
 	m := newOOBMessage(goodUID, "sys", nil)
 	if err := s.BroadcastMessage(context.TODO(), m); err != nil {
 		t.Fatal(err)
 	}
 
 	// wait for the broadcast to be sent
-	<-broadcastsSent
+	<-ev.bcastSent
 
 	if len(c.broadcasts) != 1 {
 		t.Errorf("client broadcasts received: %d, expected 1", len(c.broadcasts))
@@ -202,7 +202,7 @@ func TestBroadcast(t *testing.T) {
 
 func TestConsume(t *testing.T) {
 	mc := &mockConsumer{}
-	s, l := startTestServer(mc)
+	s, l, _ := startTestServer(mc)
 	defer l.Close()
 	defer s.Shutdown()
 
@@ -222,14 +222,7 @@ func TestConsume(t *testing.T) {
 }
 
 func TestCloseOne(t *testing.T) {
-	// create this channel so we can figure out when the async
-	// broadcast is complete.  Destroy it when the test is finished.
-	broadcastsSent = make(chan protocol.Message, 100)
-	defer func() {
-		broadcastsSent = nil
-	}()
-
-	s, l := startTestServer(nil)
+	s, l, ev := startTestServer(nil)
 	defer l.Close()
 	defer s.Shutdown()
 
@@ -238,6 +231,8 @@ func TestCloseOne(t *testing.T) {
 	if err := c.AuthClient().Authenticate(context.TODO(), goodToken); err != nil {
 		t.Fatal(err)
 	}
+
+	<-ev.perUIDCreated
 
 	ch := make(chan *Stats)
 	s.statsCh <- ch
@@ -255,13 +250,13 @@ func TestCloseOne(t *testing.T) {
 		t.Logf("broadcast error: %s", err)
 	}
 
-	// wait for the message to be broadcast
-	<-broadcastsSent
-
 	// make sure it didn't receive the broadcast
 	if len(c.broadcasts) != 0 {
 		t.Errorf("c broadcasts: %d, expected 0", len(c.broadcasts))
 	}
+
+	// wait for the perUID server to be shutdown
+	<-ev.perUIDDestroyed
 
 	// and the user server should be deleted:
 	s.statsCh <- ch
@@ -272,14 +267,7 @@ func TestCloseOne(t *testing.T) {
 }
 
 func TestCloseConnect(t *testing.T) {
-	// create this channel so we can figure out when the async
-	// broadcast is complete.  Destroy it when the test is finished.
-	broadcastsSent = make(chan protocol.Message, 100)
-	defer func() {
-		broadcastsSent = nil
-	}()
-
-	s, l := startTestServer(nil)
+	s, l, ev := startTestServer(nil)
 	defer l.Close()
 	defer s.Shutdown()
 
@@ -296,6 +284,10 @@ func TestCloseConnect(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	<-ev.connCreated
+	<-ev.connDestroyed
+	<-ev.connCreated
+
 	// broadcast a message to goodUID
 	m := newOOBMessage(goodUID, "sys", nil)
 	if err := s.BroadcastMessage(context.TODO(), m); err != nil {
@@ -303,15 +295,14 @@ func TestCloseConnect(t *testing.T) {
 		t.Logf("broadcast error: %s", err)
 	}
 
-	// wait for the broadcast to be sent
-	<-broadcastsSent
+	<-ev.bcastSent
 
 	// the user server should still exist due to c2:
 	ch := make(chan *Stats)
 	s.statsCh <- ch
 	stats := <-ch
 	if stats.UserServerCount != 1 {
-		t.Errorf("user servers: %d, expected 0", stats.UserServerCount)
+		t.Errorf("user servers: %d, expected 1", stats.UserServerCount)
 	}
 
 	// c1 shouldn't have received the broadcast:
@@ -326,14 +317,7 @@ func TestCloseConnect(t *testing.T) {
 }
 
 func TestCloseConnect2(t *testing.T) {
-	// create this channel so we can figure out when the async
-	// broadcast is complete.  Destroy it when the test is finished.
-	broadcastsSent = make(chan protocol.Message, 100)
-	defer func() {
-		broadcastsSent = nil
-	}()
-
-	s, l := startTestServer(nil)
+	s, l, ev := startTestServer(nil)
 	defer l.Close()
 	defer s.Shutdown()
 
@@ -352,14 +336,15 @@ func TestCloseConnect2(t *testing.T) {
 		t.Logf("broadcast error: %s", err)
 	}
 
-	// wait for the broadcast to be sent
-	<-broadcastsSent
-
 	c2 := newClient(l.Addr())
 	defer c2.Shutdown()
 	if err := c2.AuthClient().Authenticate(context.TODO(), goodToken); err != nil {
 		t.Fatal(err)
 	}
+
+	// wait for two connection created events
+	<-ev.connCreated
+	<-ev.connCreated
 
 	// the user server should exist due to c2:
 	ch := make(chan *Stats)
@@ -381,7 +366,7 @@ func TestCloseConnect2(t *testing.T) {
 }
 
 func TestCloseConnect3(t *testing.T) {
-	s, l := startTestServer(nil)
+	s, l, ev := startTestServer(nil)
 	defer l.Close()
 	defer s.Shutdown()
 
@@ -399,11 +384,38 @@ func TestCloseConnect3(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// wait for two connection created events
+	<-ev.connCreated
+	<-ev.connCreated
+
+	// broadcast a message to goodUID
+	m := newOOBMessage(goodUID, "sys", nil)
+	if err := s.BroadcastMessage(context.TODO(), m); err != nil {
+		// an error here is ok, as it could be about conn1 being closed:
+		t.Logf("broadcast error: %s", err)
+	}
+
+	// wait for the broadcast to be sent
+	<-ev.bcastSent
+
+	// wait for c1 connection destroyed
+	<-ev.connDestroyed
+
 	// the user server should exist due to c2:
 	ch := make(chan *Stats)
 	s.statsCh <- ch
 	stats := <-ch
 	if stats.UserServerCount != 1 {
 		t.Errorf("user servers: %d, expected 1", stats.UserServerCount)
+	}
+
+	// c1 shouldn't have received the broadcast:
+	if len(c1.broadcasts) != 0 {
+		t.Errorf("c1 broadcasts: %d, expected 0", len(c1.broadcasts))
+	}
+
+	// c2 should have received the broadcast:
+	if len(c2.broadcasts) != 1 {
+		t.Errorf("c2 broadcasts: %d, expected 1", len(c2.broadcasts))
 	}
 }

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -233,14 +233,11 @@ func TestCloseOne(t *testing.T) {
 	defer l.Close()
 	defer s.Shutdown()
 
-	fmt.Printf("X1\n")
 	c := newClient(l.Addr())
-	fmt.Printf("X2\n")
 
 	if err := c.AuthClient().Authenticate(context.TODO(), goodToken); err != nil {
 		t.Fatal(err)
 	}
-	fmt.Printf("X3\n")
 
 	ch := make(chan *Stats)
 	s.statsCh <- ch
@@ -249,9 +246,7 @@ func TestCloseOne(t *testing.T) {
 		t.Errorf("user servers: %d, expected 1", stats.UserServerCount)
 	}
 
-	fmt.Printf("X4\n")
 	c.Shutdown()
-	fmt.Printf("X5\n")
 
 	// broadcast a message to goodUID
 	m := newOOBMessage(goodUID, "sys", nil)
@@ -263,17 +258,14 @@ func TestCloseOne(t *testing.T) {
 	// wait for the message to be broadcast
 	<-broadcastsSent
 
-	fmt.Printf("X6\n")
 	// make sure it didn't receive the broadcast
 	if len(c.broadcasts) != 0 {
 		t.Errorf("c broadcasts: %d, expected 0", len(c.broadcasts))
 	}
 
-	fmt.Printf("X7\n")
 	// and the user server should be deleted:
 	s.statsCh <- ch
 	stats = <-ch
-	fmt.Printf("X8\n")
 	if stats.UserServerCount != 0 {
 		t.Errorf("user servers: %d, expected 0", stats.UserServerCount)
 	}

--- a/rpc/user_server.go
+++ b/rpc/user_server.go
@@ -1,11 +1,9 @@
 package rpc
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"log"
-	"strings"
 
 	rpc "github.com/keybase/go-framed-msgpack-rpc"
 	protocol "github.com/keybase/gregor/protocol/go"
@@ -97,18 +95,13 @@ func (s *perUIDServer) broadcast(a messageArgs) {
 		log.Printf("uid %x broadcast to %d", s.uid, id)
 		oc := protocol.OutgoingClient{Cli: rpc.NewClient(conn.xprt, nil)}
 		if err := oc.BroadcastMessage(a.c, a.m); err != nil {
+			// Just log error messages...
 			errMsgs = append(errMsgs, fmt.Sprintf("[connection %d]: %s", id, err))
 
 			if s.isConnDown(err) {
 				s.removeConnection(conn, id)
 			}
 		}
-	}
-
-	if len(errMsgs) == 0 {
-		a.retCh <- nil
-	} else {
-		a.retCh <- errors.New(strings.Join(errMsgs, ", "))
 	}
 
 	if len(s.conns) == 0 {

--- a/rpc/user_server.go
+++ b/rpc/user_server.go
@@ -1,7 +1,6 @@
 package rpc
 
 import (
-	"fmt"
 	"io"
 	"log"
 
@@ -54,34 +53,22 @@ func (s *perUIDServer) logError(prefix string, err error) {
 }
 
 func (s *perUIDServer) serve() {
-	fmt.Printf("serving it up!!!!\n")
 	for {
-		fmt.Printf("F1\n")
 		select {
 		case a := <-s.newConnectionCh:
-			fmt.Printf("F2\n")
 			s.logError("addConn", s.addConn(a))
 		case a := <-s.sendBroadcastCh:
-			fmt.Printf("J0\n")
 			s.broadcast(a)
 		case <-s.closeListenCh:
-			fmt.Printf("F3\n")
 			s.checkClosed()
 			s.tryShutdown()
-			fmt.Printf("F5\n")
 		case <-s.tryShutdownCh:
-			fmt.Printf("F6\n")
 			s.tryShutdown()
-			fmt.Printf("F7\n")
 		case <-s.parentShutdownCh:
-			fmt.Printf("F8\n")
 			s.removeAllConns()
-			fmt.Printf("F9\n")
 			return
 		case <-s.selfShutdownCh:
-			fmt.Printf("FA\n")
 			s.removeAllConns()
-			fmt.Printf("FB\n")
 			return
 		}
 	}
@@ -95,15 +82,11 @@ func (s *perUIDServer) addConn(a *connectionArgs) error {
 }
 
 func (s *perUIDServer) broadcast(a messageArgs) {
-	var errMsgs []string
-	fmt.Printf("J1\n")
 	for id, conn := range s.conns {
-		fmt.Printf("J2\n")
 		log.Printf("uid %x broadcast to %d", s.uid, id)
 		oc := protocol.OutgoingClient{Cli: rpc.NewClient(conn.xprt, nil)}
 		if err := oc.BroadcastMessage(a.c, a.m); err != nil {
-			// Just log error messages...
-			errMsgs = append(errMsgs, fmt.Sprintf("[connection %d]: %s", id, err))
+			log.Printf("[connection %d]: %s", id, err)
 
 			if s.isConnDown(err) {
 				s.removeConnection(conn, id)
@@ -135,10 +118,7 @@ func (s *perUIDServer) tryShutdown() {
 		uid:        s.uid,
 		lastConnID: s.lastConnID,
 	}
-	fmt.Printf("T1\n")
 	s.parentConfirmCh <- args
-	fmt.Printf("T2\n")
-	fmt.Printf("T3\n")
 }
 
 func (s *perUIDServer) checkClosed() {

--- a/rpc/user_server.go
+++ b/rpc/user_server.go
@@ -114,6 +114,12 @@ func (s *perUIDServer) broadcast(a messageArgs) {
 	if len(s.conns) == 0 {
 		s.tryShutdownCh <- true
 	}
+
+	// if the global broadcastsSent channel exists, put the message on it.
+	// (this is primarily for testing purposes)
+	if broadcastsSent != nil {
+		broadcastsSent <- a.m
+	}
 }
 
 // tryShutdown checks if it is ok to shutdown.  Returns true if it

--- a/util/stress.bash
+++ b/util/stress.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash -e
+
+# this came from:
+# http://dave.cheney.net/2013/06/19/stress-test-your-go-packages
+
+go test -c
+# comment above and uncomment below to enable the race builder
+#go test -c -race
+PKG=$(basename $(pwd))
+
+while true ; do 
+        export GOMAXPROCS=$[ 1 + $[ RANDOM % 128 ]]
+        ./$PKG.test $@ 2>&1
+done


### PR DESCRIPTION
- sending a broadcast should not block the main thread, so make the whole broadcast pipeline async
- this breaks tests, but they were broken previously (see CORE-2882) so we need to explore a different testing strategy.  in particular, we might need artificial synchronization to wait until clients get broadcasts, available just for testing.  if broadcast is async, there's nothing internally to sychronize on.  but the clients can tell us in the test when the get the message, and/or we can deadlock indefinitely if they never arrive (which will also break tests)