### PR TITLE
fix deadlock and make deadlocking part of the test

### DIFF
--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -44,6 +44,7 @@ func startTestServer(x gregor.NetworkInterfaceIncoming) (*Server, net.Listener, 
 	s := NewServer()
 	s.auth = mockAuth{}
 	s.events = ev
+	s.useDeadlocker = true
 	l := newLocalListener()
 	go s.Serve(x)
 	go s.ListenLoop(l)

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -286,6 +286,7 @@ func TestCloseConnect(t *testing.T) {
 	}
 
 	<-ev.connCreated
+	<-ev.connDestroyed
 	<-ev.connCreated
 
 	// broadcast a message to goodUID
@@ -295,7 +296,6 @@ func TestCloseConnect(t *testing.T) {
 		t.Logf("broadcast error: %s", err)
 	}
 
-	<-ev.connDestroyed
 	<-ev.bcastSent
 
 	// the user server should still exist due to c2:

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -286,7 +286,8 @@ func TestCloseConnect(t *testing.T) {
 	}
 
 	<-ev.connCreated
-	<-ev.connDestroyed
+	// taking this out gets rid of the deadlock:
+	// <-ev.connDestroyed
 	<-ev.connCreated
 
 	// broadcast a message to goodUID

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -286,8 +286,6 @@ func TestCloseConnect(t *testing.T) {
 	}
 
 	<-ev.connCreated
-	// taking this out gets rid of the deadlock:
-	// <-ev.connDestroyed
 	<-ev.connCreated
 
 	// broadcast a message to goodUID
@@ -297,6 +295,7 @@ func TestCloseConnect(t *testing.T) {
 		t.Logf("broadcast error: %s", err)
 	}
 
+	<-ev.connDestroyed
 	<-ev.bcastSent
 
 	// the user server should still exist due to c2:

--- a/rpc/user_server.go
+++ b/rpc/user_server.go
@@ -34,8 +34,8 @@ func newPerUIDServer(uid protocol.UID, parentConfirmCh chan confirmUIDShutdownAr
 		conns:            make(map[connectionID]*connection),
 		newConnectionCh:  make(chan *connectionArgs, 1),
 		sendBroadcastCh:  make(chan messageArgs, 1),
-		tryShutdownCh:    make(chan bool, 1), // buffered so it can receive inside serve()
-		closeListenCh:    make(chan error, 1),
+		tryShutdownCh:    make(chan bool, 1),    // buffered so it can receive inside serve()
+		closeListenCh:    make(chan error, 100), // each connection uses the same closeListenCh, so buffer it more than 1
 		parentConfirmCh:  parentConfirmCh,
 		parentShutdownCh: shutdownCh,
 		selfShutdownCh:   make(chan struct{}),
@@ -99,9 +99,11 @@ func (s *perUIDServer) addConn(a *connectionArgs) error {
 	// because we started listening too late. So what we might do instead is
 	// check that we're connected, and if not, to send an artificial message
 	// on that channel.
-	if !a.c.xprt.IsConnected() {
-		s.closeListenCh <- nil
-	}
+	/*
+		if !a.c.xprt.IsConnected() {
+			s.closeListenCh <- nil
+		}
+	*/
 
 	return nil
 }

--- a/rpc/user_server.go
+++ b/rpc/user_server.go
@@ -99,11 +99,9 @@ func (s *perUIDServer) addConn(a *connectionArgs) error {
 	// because we started listening too late. So what we might do instead is
 	// check that we're connected, and if not, to send an artificial message
 	// on that channel.
-	/*
-		if !a.c.xprt.IsConnected() {
-			s.closeListenCh <- nil
-		}
-	*/
+	if !a.c.xprt.IsConnected() {
+		s.closeListenCh <- nil
+	}
 
 	return nil
 }


### PR DESCRIPTION
- the deadlock was due to a race between listening for a close and the close itself.
  if the close came first, the notification was dropped.
- fix that deadlock
- also add more delay slots for testing