### PR TITLE
Fix missing return in tryShutdown

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -224,6 +224,7 @@ func (s *Server) sendBroadcast(c context.Context, m gregor1.Message) error {
 		// even though nothing to do, create an event if
 		// an event handler in place:
 		if s.events != nil {
+			log.Printf("sendBroadcast: no PerUIDServer for %s", gregor.UIDFromMessage(m))
 			s.events.BroadcastSent(m)
 		}
 		return nil

--- a/rpc/user_server.go
+++ b/rpc/user_server.go
@@ -128,12 +128,13 @@ func (s *perUIDServer) broadcast(a messageArgs) {
 	}
 }
 
-// tryShutdown checks if it is ok to shutdown.  Returns true if it
-// is ok.
+// tryShutdown makes a request to the parent server for this
+// server to be terminated.
 func (s *perUIDServer) tryShutdown() {
 	// make sure no connections have been added
 	if len(s.conns) != 0 {
 		log.Printf("tried shutdown, but %d conns for %x", len(s.conns), s.uid)
+		return
 	}
 
 	// confirm with the server that it is ok to shutdown


### PR DESCRIPTION
r? @maxtaco 

The fix is in tryShutdown(), it was missing a return if connections were added since the shutdown request was added.

Tested with 3ns, 3ms, test -count 10000, stress.bash, stress.bash with race.