### PR TITLE
Cleanup old dismissed messages, test InnoDB

### DIFF
--- a/cleanup/cleanup.go
+++ b/cleanup/cleanup.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"database/sql"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+func main() {
+	var interval int
+	var help bool
+	var dsn string
+
+	flag.IntVar(&interval, "interval", 30, "clean messages older than interval `days`")
+	flag.BoolVar(&help, "h", false, "show help")
+	flag.BoolVar(&help, "help", false, "show help")
+	flag.StringVar(&dsn, "dsn", "gregor:@/gregor_test", "mysql dsn for gregor database")
+
+	flag.Parse()
+	if help {
+		flag.Usage()
+		os.Exit(0)
+	}
+
+	log.Printf("cleaning up dismissed messages older than %d days", interval)
+	db := database(dsn)
+	defer db.Close()
+	cleanup(db, interval)
+	log.Printf("done")
+}
+
+func database(dsn string) *sql.DB {
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		log.Fatalf("error opening database connection to %s: %s", dsn, err)
+	}
+	return db
+}
+
+func cleanup(db *sql.DB, interval int) {
+	for i := 0x00; i <= 0xff; i++ {
+		partition(db, fmt.Sprintf("%02x", i), interval)
+	}
+}
+
+func partition(db *sql.DB, prefix string, interval int) {
+	tx, err := db.Begin()
+	if err != nil {
+		log.Fatalf("error starting transaction: %s", err)
+	}
+	defer tx.Commit()
+
+	// Note that this query relies on the following foreign key reference
+	// FOREIGN KEY(uid, msgid) REFERENCES messages (uid, msgid) ON DELETE CASCADE
+	// on child tables of messages.
+	res, err := tx.Exec("DELETE FROM messages USING messages LEFT JOIN items ON (messages.uid=items.uid AND messages.msgid=items.msgid) WHERE items.uid LIKE ? AND items.dtime < DATE_SUB(NOW(), INTERVAL ? DAY)", prefix+"%", interval)
+	if err != nil {
+		tx.Rollback()
+		log.Fatalf("[%s] tx exec error: %s", prefix, err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		log.Printf("[%s] error getting rows affected: %s", prefix, err)
+		return
+	}
+
+	log.Printf("uid prefix %s, messages deleted: %d", prefix, affected)
+}

--- a/doc/mysql.md
+++ b/doc/mysql.md
@@ -15,3 +15,6 @@ space, or if table data file grows without bounds.
 Conclusion: while the InnoDB file size doesn't shrink
 after deleting rows, the space that was used by deleted 
 rows is reused for new rows.
+
+Tested on 5.7.10 on OS X and 5.6.28 on linux, same
+results.

--- a/doc/mysql.md
+++ b/doc/mysql.md
@@ -1,0 +1,17 @@
+Testing delete on InnoDB tables
+-------------------------------
+
+Curious if deleting data from InnoDB tables reclaims
+space, or if table data file grows without bounds.
+
+1. Using `util/populate.sql`, added 1M messages.
+2. `messages.ibd` after is 236MB.
+3. `DELETE FROM messages;` to remove all the rows.
+4. `messages.ibd` after is 236MB (as expected).
+5. Added 100k rows, `messages.ibd` still 236MB.
+6. Added 1M rows (total), `messages.ibd` still 236MB.
+7. Added 1.1M rows (total), `messages.ibd` now 252MB.
+
+Conclusion: while the InnoDB file size doesn't shrink
+after deleting rows, the space that was used by deleted 
+rows is reused for new rows.

--- a/storage/sql_schema.go
+++ b/storage/sql_schema.go
@@ -23,7 +23,7 @@ var schema = []string{
 		category VARCHAR(128) NOT NULL,
 		dtime DATETIME(6),
 		body BLOB,
-		FOREIGN KEY(uid, msgid) REFERENCES messages (uid, msgid),
+		FOREIGN KEY(uid, msgid) REFERENCES messages (uid, msgid) ON DELETE CASCADE,
 		PRIMARY KEY(uid, msgid)
 	)`,
 
@@ -35,6 +35,7 @@ var schema = []string{
 		uid   CHAR(32) NOT NULL,
 		msgid CHAR(32) NOT NULL,
 		ntime DATETIME(6) NOT NULL,
+		FOREIGN KEY(uid, msgid) REFERENCES messages (uid, msgid) ON DELETE CASCADE,
 		PRIMARY KEY(uid, msgid, ntime)
 	)`,
 
@@ -42,7 +43,8 @@ var schema = []string{
 		uid   CHAR(32) NOT NULL,
 		msgid CHAR(32) NOT NULL,
 		dmsgid CHAR(32) NOT NULL, -- "the message IDs to dismiss",
-		FOREIGN KEY(uid, msgid) REFERENCES messages (uid, msgid),
+		FOREIGN KEY(uid, msgid) REFERENCES messages (uid, msgid) ON DELETE CASCADE,
+		FOREIGN KEY(uid, dmsgid) REFERENCES messages (uid, msgid) ON DELETE CASCADE,
 		PRIMARY KEY(uid, msgid, dmsgid)
 	)`,
 
@@ -51,7 +53,7 @@ var schema = []string{
 		msgid CHAR(32) NOT NULL,
 		category VARCHAR(128) NOT NULL,
 		dtime DATETIME(6) NOT NULL, -- "throw out matching events before dtime",
-		FOREIGN KEY(uid, msgid) REFERENCES messages (uid, msgid),
+		FOREIGN KEY(uid, msgid) REFERENCES messages (uid, msgid) ON DELETE CASCADE,
 		PRIMARY KEY(uid, msgid, category, dtime)
 	)`,
 }

--- a/util/populate.sql
+++ b/util/populate.sql
@@ -1,0 +1,17 @@
+-- insert a bunch of random message rows into gregor db
+DELIMITER $$
+CREATE PROCEDURE insert_random_data()
+BEGIN
+  DECLARE i INT DEFAULT 0;
+
+  WHILE i < 100000 DO
+    INSERT INTO messages (uid, msgid, ctime, devid, mtype) VALUES (MD5(RAND()), MD5(RAND()), NOW(), MD5(RAND()), 1);
+    SET i = i + 1;
+  END WHILE;
+END$$
+DELIMITER ;
+
+
+CALL insert_random_data();
+
+DROP PROCEDURE insert_random_data;


### PR DESCRIPTION
The cleanup application will delete old dismissed messages in the gregor database and their related rows in other tables.

Also, tested innodb file size changes with delete operations.  See doc/mysql.md for results.

r? @maxtaco 