### PR TITLE
implement logging in gregord

### DIFF
--- a/gregord/consumer.go
+++ b/gregord/consumer.go
@@ -6,11 +6,10 @@ import (
 	"net/url"
 
 	_ "github.com/go-sql-driver/mysql"
+	rpc "github.com/keybase/go-framed-msgpack-rpc"
 	"github.com/keybase/gregor"
 	"github.com/keybase/gregor/protocol/gregor1"
 	"github.com/keybase/gregor/storage"
-
-	rpc "github.com/keybase/go-framed-msgpack-rpc"
 )
 
 type consumer struct {

--- a/gregord/flow_test.go
+++ b/gregord/flow_test.go
@@ -105,12 +105,12 @@ func startTestGregord(t *testing.T) (net.Addr, *test.Events, func()) {
 		Debug:       true,
 	}
 
-	srv := grpc.NewServer()
+	srv := grpc.NewServer(rpc.SimpleLogOutput{})
 	srv.SetAuthenticator(mockAuth{})
 	e := test.NewEvents()
 	srv.SetEventHandler(e)
 
-	consumer, err := newConsumer(u)
+	consumer, err := newConsumer(u, rpc.SimpleLogOutput{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/gregord/log.go
+++ b/gregord/log.go
@@ -43,7 +43,7 @@ var noColorFormat = `%{level:.4s} %{time:15:04:05.000} %{shortfile} %{message}`
 
 var colorFormat = "%{color}" + noColorFormat + "%{color:reset}"
 
-func newLogger() *logging.Logger {
+func newLogger() rpc.LogOutput {
 	backend := logging.NewLogBackend(os.Stderr, "", 0)
 	var format string
 	if terminal.IsTerminal(int(os.Stdout.Fd())) {
@@ -74,5 +74,5 @@ func newLogger() *logging.Logger {
 
 	logger := logging.MustGetLogger("gregord")
 	logger.SetBackend(logging.MultiLogger(backends...))
-	return logger
+	return &GoLoggingWrapperForRPC{logger}
 }

--- a/gregord/log.go
+++ b/gregord/log.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	logging "github.com/keybase/go-logging"
+	"golang.org/x/crypto/ssh/terminal"
+	"log/syslog"
+	"os"
+)
+
+// The gregor libraries don't depend on any particular logging implementation.
+// Rather they depend on the go-framed-msgpack-rpc library's LogOutput
+// interface, and they take implementation of that provided by the caller. This
+// allows client code to pass in the client's Logger object, for gregor code
+// running inside the client. Here in the server we implement the LogOutput
+// interface using the go-logging library.
+
+type GoLoggingWrapperForRPC struct {
+	inner *logging.Logger
+}
+
+func (g *GoLoggingWrapperForRPC) Error(s string, args ...interface{}) {
+	g.inner.Errorf(s, args...)
+}
+func (g *GoLoggingWrapperForRPC) Warning(s string, args ...interface{}) {
+	g.inner.Warningf(s, args...)
+}
+func (g *GoLoggingWrapperForRPC) Info(s string, args ...interface{}) {
+	g.inner.Infof(s, args...)
+}
+func (g *GoLoggingWrapperForRPC) Debug(s string, args ...interface{}) {
+	g.inner.Debugf(s, args...)
+}
+func (g *GoLoggingWrapperForRPC) Profile(s string, args ...interface{}) {
+	g.inner.Debugf(s, args...)
+}
+
+var noColorFormat = `%{level:.4s} %{time:15:04:05.000} %{shortfile} %{message}`
+
+var colorFormat = "%{color}" + noColorFormat + "%{color:reset}"
+
+func newLogger() *logging.Logger {
+	backend := logging.NewLogBackend(os.Stderr, "", 0)
+	var format string
+	if terminal.IsTerminal(int(os.Stdout.Fd())) {
+		format = colorFormat
+	} else {
+		format = noColorFormat
+	}
+	formattedBackend := logging.NewBackendFormatter(backend, logging.MustStringFormatter(format))
+	backends := []logging.Backend{formattedBackend}
+
+	// Add a syslog backend if the right env vars are present.
+	// TODO: *Remove* the stdout backend in this case?
+	syslogIP := os.Getenv("LOGGLY_PORT_514_UDP_ADDR")
+	syslogPort := os.Getenv("LOGGLY_PORT_514_UDP_PORT")
+	if syslogIP != "" && syslogPort != "" {
+		syslogURL := syslogIP + ":" + syslogPort
+		syslogWriter, err := syslog.Dial("udp", syslogURL, 0, "")
+		if err != nil {
+			fmt.Println(err)
+			fmt.Printf("ERROR failed to connect to syslog at %s\n", syslogURL)
+			os.Exit(1)
+		}
+		fmt.Printf("connected to syslog at %s\n", syslogURL)
+		syslogBackend := logging.SyslogBackend{Writer: syslogWriter}
+		formattedSyslog := logging.NewBackendFormatter(&syslogBackend, logging.MustStringFormatter(format))
+		backends = append(backends, formattedSyslog)
+	}
+
+	logger := logging.MustGetLogger("gregord")
+	logger.SetBackend(logging.MultiLogger(backends...))
+	return logger
+}

--- a/gregord/log.go
+++ b/gregord/log.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
-	logging "github.com/keybase/go-logging"
-	"golang.org/x/crypto/ssh/terminal"
 	"log/syslog"
 	"os"
+
+	rpc "github.com/keybase/go-framed-msgpack-rpc"
+	logging "github.com/keybase/go-logging"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 // The gregor libraries don't depend on any particular logging implementation.
@@ -18,6 +20,8 @@ import (
 type GoLoggingWrapperForRPC struct {
 	inner *logging.Logger
 }
+
+var _ rpc.LogOutput = (*GoLoggingWrapperForRPC)(nil)
 
 func (g *GoLoggingWrapperForRPC) Error(s string, args ...interface{}) {
 	g.inner.Errorf(s, args...)

--- a/gregord/main.go
+++ b/gregord/main.go
@@ -6,11 +6,10 @@ import (
 
 	"github.com/jonboulle/clockwork"
 	keybase1 "github.com/keybase/client/go/protocol"
-	"golang.org/x/net/context"
-
 	rpc "github.com/keybase/go-framed-msgpack-rpc"
 	"github.com/keybase/gregor/protocol/gregor1"
 	grpc "github.com/keybase/gregor/rpc"
+	"golang.org/x/net/context"
 )
 
 func main() {

--- a/gregord/main.go
+++ b/gregord/main.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	"log"
+	"fmt"
+	"log/syslog"
 	"os"
 	"time"
 
@@ -12,38 +13,44 @@ import (
 	rpc "github.com/keybase/go-framed-msgpack-rpc"
 	"github.com/keybase/gregor/protocol/gregor1"
 	grpc "github.com/keybase/gregor/rpc"
+
+	logging "github.com/keybase/go-logging"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 func main() {
+	logger := newLogger()
+	rpcLogger := &GoLoggingWrapperForRPC{logger}
+
 	opts, err := ParseOptions(os.Args)
 	if err != nil {
-		log.Fatal(err)
+		logger.Fatal(err)
 	}
 
-	srv := grpc.NewServer()
+	srv := grpc.NewServer(rpcLogger)
 
 	if opts.MockAuth {
 		srv.SetAuthenticator(mockAuth{})
 	} else {
 		conn, err := opts.SessionServer.Dial()
 		if err != nil {
-			log.Fatal(err)
+			logger.Fatal(err)
 		}
-		Cli := rpc.NewClient(rpc.NewTransport(conn, nil, keybase1.WrapError), keybase1.ErrorUnwrapper{})
+		Cli := rpc.NewClient(rpc.NewTransport(conn, rpc.NewSimpleLogFactory(rpcLogger, nil), keybase1.WrapError), keybase1.ErrorUnwrapper{})
 		sc := grpc.NewSessionCacher(gregor1.AuthClient{Cli}, clockwork.NewRealClock(), 10*time.Minute)
 		srv.SetAuthenticator(sc)
 		defer sc.Close()
 	}
 
 	// create a message consumer state machine
-	consumer, err := newConsumer(opts.MysqlDSN)
+	consumer, err := newConsumer(opts.MysqlDSN, rpcLogger)
 	if err != nil {
-		log.Fatal(err)
+		logger.Fatal(err)
 	}
 	defer consumer.shutdown()
 	go srv.Serve(consumer)
 
-	log.Fatal(newMainServer(opts, srv).listenAndServe())
+	logger.Fatal(newMainServer(opts, srv).listenAndServe())
 }
 
 type mockAuth struct{}
@@ -56,3 +63,61 @@ func (m mockAuth) RevokeSessionIDs(_ context.Context, sessionIDs []gregor1.Sessi
 }
 
 var _ gregor1.AuthInterface = mockAuth{}
+
+type GoLoggingWrapperForRPC struct {
+	inner *logging.Logger
+}
+
+func (g *GoLoggingWrapperForRPC) Error(s string, args ...interface{}) {
+	g.inner.Errorf(s, args...)
+}
+func (g *GoLoggingWrapperForRPC) Warning(s string, args ...interface{}) {
+	g.inner.Warningf(s, args...)
+}
+func (g *GoLoggingWrapperForRPC) Info(s string, args ...interface{}) {
+	g.inner.Infof(s, args...)
+}
+func (g *GoLoggingWrapperForRPC) Debug(s string, args ...interface{}) {
+	g.inner.Debugf(s, args...)
+}
+func (g *GoLoggingWrapperForRPC) Profile(s string, args ...interface{}) {
+	g.inner.Debugf(s, args...)
+}
+
+var noColorFormat = `%{level:.4s} %{time:15:04:05.000} %{shortfile} %{message}`
+
+var colorFormat = "%{color}" + noColorFormat + "%{color:reset}"
+
+func newLogger() *logging.Logger {
+	backend := logging.NewLogBackend(os.Stderr, "", 0)
+	var format string
+	if terminal.IsTerminal(int(os.Stdout.Fd())) {
+		format = colorFormat
+	} else {
+		format = noColorFormat
+	}
+	formattedBackend := logging.NewBackendFormatter(backend, logging.MustStringFormatter(format))
+	backends := []logging.Backend{formattedBackend}
+
+	// Add a syslog backend if the right env vars are present.
+	// TODO: *Remove* the stdout backend in this case?
+	syslogIP := os.Getenv("LOGGLY_PORT_514_UDP_ADDR")
+	syslogPort := os.Getenv("LOGGLY_PORT_514_UDP_PORT")
+	if syslogIP != "" && syslogPort != "" {
+		syslogURL := syslogIP + ":" + syslogPort
+		syslogWriter, err := syslog.Dial("udp", syslogURL, 0, "")
+		if err != nil {
+			fmt.Println(err)
+			fmt.Printf("ERROR failed to connect to syslog at %s\n", syslogURL)
+			os.Exit(1)
+		}
+		fmt.Printf("connected to syslog at %s\n", syslogURL)
+		syslogBackend := logging.SyslogBackend{Writer: syslogWriter}
+		formattedSyslog := logging.NewBackendFormatter(&syslogBackend, logging.MustStringFormatter(format))
+		backends = append(backends, formattedSyslog)
+	}
+
+	logger := logging.MustGetLogger("gregord")
+	logger.SetBackend(logging.MultiLogger(backends...))
+	return logger
+}

--- a/gregord/main.go
+++ b/gregord/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"log/syslog"
 	"os"
 	"time"
 
@@ -13,9 +11,6 @@ import (
 	rpc "github.com/keybase/go-framed-msgpack-rpc"
 	"github.com/keybase/gregor/protocol/gregor1"
 	grpc "github.com/keybase/gregor/rpc"
-
-	logging "github.com/keybase/go-logging"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 func main() {
@@ -63,61 +58,3 @@ func (m mockAuth) RevokeSessionIDs(_ context.Context, sessionIDs []gregor1.Sessi
 }
 
 var _ gregor1.AuthInterface = mockAuth{}
-
-type GoLoggingWrapperForRPC struct {
-	inner *logging.Logger
-}
-
-func (g *GoLoggingWrapperForRPC) Error(s string, args ...interface{}) {
-	g.inner.Errorf(s, args...)
-}
-func (g *GoLoggingWrapperForRPC) Warning(s string, args ...interface{}) {
-	g.inner.Warningf(s, args...)
-}
-func (g *GoLoggingWrapperForRPC) Info(s string, args ...interface{}) {
-	g.inner.Infof(s, args...)
-}
-func (g *GoLoggingWrapperForRPC) Debug(s string, args ...interface{}) {
-	g.inner.Debugf(s, args...)
-}
-func (g *GoLoggingWrapperForRPC) Profile(s string, args ...interface{}) {
-	g.inner.Debugf(s, args...)
-}
-
-var noColorFormat = `%{level:.4s} %{time:15:04:05.000} %{shortfile} %{message}`
-
-var colorFormat = "%{color}" + noColorFormat + "%{color:reset}"
-
-func newLogger() *logging.Logger {
-	backend := logging.NewLogBackend(os.Stderr, "", 0)
-	var format string
-	if terminal.IsTerminal(int(os.Stdout.Fd())) {
-		format = colorFormat
-	} else {
-		format = noColorFormat
-	}
-	formattedBackend := logging.NewBackendFormatter(backend, logging.MustStringFormatter(format))
-	backends := []logging.Backend{formattedBackend}
-
-	// Add a syslog backend if the right env vars are present.
-	// TODO: *Remove* the stdout backend in this case?
-	syslogIP := os.Getenv("LOGGLY_PORT_514_UDP_ADDR")
-	syslogPort := os.Getenv("LOGGLY_PORT_514_UDP_PORT")
-	if syslogIP != "" && syslogPort != "" {
-		syslogURL := syslogIP + ":" + syslogPort
-		syslogWriter, err := syslog.Dial("udp", syslogURL, 0, "")
-		if err != nil {
-			fmt.Println(err)
-			fmt.Printf("ERROR failed to connect to syslog at %s\n", syslogURL)
-			os.Exit(1)
-		}
-		fmt.Printf("connected to syslog at %s\n", syslogURL)
-		syslogBackend := logging.SyslogBackend{Writer: syslogWriter}
-		formattedSyslog := logging.NewBackendFormatter(&syslogBackend, logging.MustStringFormatter(format))
-		backends = append(backends, formattedSyslog)
-	}
-
-	logger := logging.MustGetLogger("gregord")
-	logger.SetBackend(logging.MultiLogger(backends...))
-	return logger
-}

--- a/gregord/vendor/github.com/keybase/go-logging/CHANGELOG.md
+++ b/gregord/vendor/github.com/keybase/go-logging/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 2.0.0-rc1 (2016-02-11)
+
+Time flies and it has been three years since this package was first released.
+There have been a couple of API changes I have wanted to do for some time but
+I've tried to maintain backwards compatibility. Some inconsistencies in the
+API have started to show, proper vendor support in Go out of the box and
+the fact that `go vet` will give warnings -- I have decided to bump the major
+version.
+
+* Make eg. `Info` and `Infof` do different things. You want to change all calls
+	to `Info` with a string format go to `Infof` etc. In many cases, `go vet` will
+	guide you.
+* `Id` in `Record` is now called `ID`
+
+## 1.0.0 (2013-02-21)
+
+Initial release

--- a/gregord/vendor/github.com/keybase/go-logging/CONTRIBUTORS
+++ b/gregord/vendor/github.com/keybase/go-logging/CONTRIBUTORS
@@ -1,0 +1,5 @@
+Alec Thomas <alec@swapoff.org>
+Guilhem Lettron <guilhem.lettron@optiflows.com>
+Ivan Daniluk <ivan.daniluk@gmail.com>
+Nimi Wariboko Jr <nimi@channelmeter.com>
+Róbert Selvek <robert.selvek@gmail.com>

--- a/gregord/vendor/github.com/keybase/go-logging/LICENSE
+++ b/gregord/vendor/github.com/keybase/go-logging/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2013 Örjan Persson. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/gregord/vendor/github.com/keybase/go-logging/README.md
+++ b/gregord/vendor/github.com/keybase/go-logging/README.md
@@ -1,0 +1,93 @@
+## Golang logging library
+
+[![godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/op/go-logging) [![build](https://img.shields.io/travis/op/go-logging.svg?style=flat)](https://travis-ci.org/op/go-logging)
+
+Package logging implements a logging infrastructure for Go. Its output format
+is customizable and supports different logging backends like syslog, file and
+memory. Multiple backends can be utilized with different log levels per backend
+and logger.
+
+**_NOTE:_** backwards compatibility promise have been dropped for master. Please
+vendor this package or use `gopkg.in/op/go-logging.v1` for previous version. See
+[changelog](CHANGELOG.md) for details.
+
+## Example
+
+Let's have a look at an [example](examples/example.go) which demonstrates most
+of the features found in this library.
+
+[![Example Output](examples/example.png)](examples/example.go)
+
+```go
+package main
+
+import (
+	"os"
+
+	"github.com/op/go-logging"
+)
+
+var log = logging.MustGetLogger("example")
+
+// Example format string. Everything except the message has a custom color
+// which is dependent on the log level. Many fields have a custom output
+// formatting too, eg. the time returns the hour down to the milli second.
+var format = logging.MustStringFormatter(
+	`%{color}%{time:15:04:05.000} %{shortfunc} ▶ %{level:.4s} %{id:03x}%{color:reset} %{message}`,
+)
+
+// Password is just an example type implementing the Redactor interface. Any
+// time this is logged, the Redacted() function will be called.
+type Password string
+
+func (p Password) Redacted() interface{} {
+	return logging.Redact(string(p))
+}
+
+func main() {
+	// For demo purposes, create two backend for os.Stderr.
+	backend1 := logging.NewLogBackend(os.Stderr, "", 0)
+	backend2 := logging.NewLogBackend(os.Stderr, "", 0)
+
+	// For messages written to backend2 we want to add some additional
+	// information to the output, including the used log level and the name of
+	// the function.
+	backend2Formatter := logging.NewBackendFormatter(backend2, format)
+
+	// Only errors and more severe messages should be sent to backend1
+	backend1Leveled := logging.AddModuleLevel(backend1)
+	backend1Leveled.SetLevel(logging.ERROR, "")
+
+	// Set the backends to be used.
+	logging.SetBackend(backend1Leveled, backend2Formatter)
+
+	log.Debugf("debug %s", Password("secret"))
+	log.Info("info")
+	log.Notice("notice")
+	log.Warning("warning")
+	log.Error("err")
+	log.Critical("crit")
+}
+```
+
+## Installing
+
+### Using *go get*
+
+    $ go get github.com/op/go-logging
+
+After this command *go-logging* is ready to use. Its source will be in:
+
+    $GOPATH/src/pkg/github.com/op/go-logging
+
+You can use `go get -u` to update the package.
+
+## Documentation
+
+For docs, see http://godoc.org/github.com/op/go-logging or run:
+
+    $ godoc github.com/op/go-logging
+
+## Additional resources
+
+* [wslog](https://godoc.org/github.com/cryptix/go/logging/wslog) -- exposes log messages through a WebSocket.

--- a/gregord/vendor/github.com/keybase/go-logging/backend.go
+++ b/gregord/vendor/github.com/keybase/go-logging/backend.go
@@ -1,0 +1,50 @@
+// Copyright 2013, Örjan Persson. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package logging
+
+import (
+	"sync"
+)
+
+// defaultBackend is the backend used for all logging calls.
+var defaultBackend LeveledBackend
+var defaultBackendMutex sync.Mutex
+
+func init() {
+	defaultBackendMutex = sync.Mutex{}
+}
+
+// Backend is the interface which a log backend need to implement to be able to
+// be used as a logging backend.
+type Backend interface {
+	Log(Level, int, *Record) error
+}
+
+// SetBackend replaces the backend currently set with the given new logging
+// backend.
+func SetBackend(backends ...Backend) LeveledBackend {
+	var backend Backend
+	if len(backends) == 1 {
+		backend = backends[0]
+	} else {
+		backend = MultiLogger(backends...)
+	}
+
+	defaultBackendMutex.Lock()
+	defaultBackend = AddModuleLevel(backend)
+	defaultBackendMutex.Unlock()
+	return defaultBackend
+}
+
+// SetLevel sets the logging level for the specified module. The module
+// corresponds to the string specified in GetLogger.
+func SetLevel(level Level, module string) {
+	defaultBackend.SetLevel(level, module)
+}
+
+// GetLevel returns the logging level for the specified module.
+func GetLevel(module string) Level {
+	return defaultBackend.GetLevel(module)
+}

--- a/gregord/vendor/github.com/keybase/go-logging/format.go
+++ b/gregord/vendor/github.com/keybase/go-logging/format.go
@@ -1,0 +1,414 @@
+// Copyright 2013, Örjan Persson. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package logging
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// TODO see Formatter interface in fmt/print.go
+// TODO try text/template, maybe it have enough performance
+// TODO other template systems?
+// TODO make it possible to specify formats per backend?
+type fmtVerb int
+
+const (
+	fmtVerbTime fmtVerb = iota
+	fmtVerbLevel
+	fmtVerbID
+	fmtVerbPid
+	fmtVerbProgram
+	fmtVerbModule
+	fmtVerbMessage
+	fmtVerbLongfile
+	fmtVerbShortfile
+	fmtVerbLongpkg
+	fmtVerbShortpkg
+	fmtVerbLongfunc
+	fmtVerbShortfunc
+	fmtVerbCallpath
+	fmtVerbLevelColor
+
+	// Keep last, there are no match for these below.
+	fmtVerbUnknown
+	fmtVerbStatic
+)
+
+var fmtVerbs = []string{
+	"time",
+	"level",
+	"id",
+	"pid",
+	"program",
+	"module",
+	"message",
+	"longfile",
+	"shortfile",
+	"longpkg",
+	"shortpkg",
+	"longfunc",
+	"shortfunc",
+	"callpath",
+	"color",
+}
+
+const rfc3339Milli = "2006-01-02T15:04:05.999Z07:00"
+
+var defaultVerbsLayout = []string{
+	rfc3339Milli,
+	"s",
+	"d",
+	"d",
+	"s",
+	"s",
+	"s",
+	"s",
+	"s",
+	"s",
+	"s",
+	"s",
+	"s",
+	"0",
+	"",
+}
+
+var (
+	pid     = os.Getpid()
+	program = filepath.Base(os.Args[0])
+)
+
+func getFmtVerbByName(name string) fmtVerb {
+	for i, verb := range fmtVerbs {
+		if name == verb {
+			return fmtVerb(i)
+		}
+	}
+	return fmtVerbUnknown
+}
+
+// Formatter is the required interface for a custom log record formatter.
+type Formatter interface {
+	Format(calldepth int, r *Record, w io.Writer) error
+}
+
+// formatter is used by all backends unless otherwise overriden.
+var formatter struct {
+	sync.RWMutex
+	def Formatter
+}
+
+func getFormatter() Formatter {
+	formatter.RLock()
+	defer formatter.RUnlock()
+	return formatter.def
+}
+
+var (
+	// DefaultFormatter is the default formatter used and is only the message.
+	DefaultFormatter = MustStringFormatter("%{message}")
+
+	// GlogFormatter mimics the glog format
+	GlogFormatter = MustStringFormatter("%{level:.1s}%{time:0102 15:04:05.999999} %{pid} %{shortfile}] %{message}")
+)
+
+// SetFormatter sets the default formatter for all new backends. A backend will
+// fetch this value once it is needed to format a record. Note that backends
+// will cache the formatter after the first point. For now, make sure to set
+// the formatter before logging.
+func SetFormatter(f Formatter) {
+	formatter.Lock()
+	defer formatter.Unlock()
+	formatter.def = f
+}
+
+var formatRe = regexp.MustCompile(`%{([a-z]+)(?::(.*?[^\\]))?}`)
+
+type part struct {
+	verb   fmtVerb
+	layout string
+}
+
+// stringFormatter contains a list of parts which explains how to build the
+// formatted string passed on to the logging backend.
+type stringFormatter struct {
+	parts []part
+}
+
+// NewStringFormatter returns a new Formatter which outputs the log record as a
+// string based on the 'verbs' specified in the format string.
+//
+// The verbs:
+//
+// General:
+//     %{id}        Sequence number for log message (uint64).
+//     %{pid}       Process id (int)
+//     %{time}      Time when log occurred (time.Time)
+//     %{level}     Log level (Level)
+//     %{module}    Module (string)
+//     %{program}   Basename of os.Args[0] (string)
+//     %{message}   Message (string)
+//     %{longfile}  Full file name and line number: /a/b/c/d.go:23
+//     %{shortfile} Final file name element and line number: d.go:23
+//     %{callpath}  Callpath like main.a.b.c...c  "..." meaning recursive call ~. meaning truncated path
+//     %{color}     ANSI color based on log level
+//
+// For normal types, the output can be customized by using the 'verbs' defined
+// in the fmt package, eg. '%{id:04d}' to make the id output be '%04d' as the
+// format string.
+//
+// For time.Time, use the same layout as time.Format to change the time format
+// when output, eg "2006-01-02T15:04:05.999Z-07:00".
+//
+// For the 'color' verb, the output can be adjusted to either use bold colors,
+// i.e., '%{color:bold}' or to reset the ANSI attributes, i.e.,
+// '%{color:reset}' Note that if you use the color verb explicitly, be sure to
+// reset it or else the color state will persist past your log message.  e.g.,
+// "%{color:bold}%{time:15:04:05} %{level:-8s}%{color:reset} %{message}" will
+// just colorize the time and level, leaving the message uncolored.
+//
+// For the 'callpath' verb, the output can be adjusted to limit the printing
+// the stack depth. i.e. '%{callpath:3}' will print '~.a.b.c'
+//
+// Colors on Windows is unfortunately not supported right now and is currently
+// a no-op.
+//
+// There's also a couple of experimental 'verbs'. These are exposed to get
+// feedback and needs a bit of tinkering. Hence, they might change in the
+// future.
+//
+// Experimental:
+//     %{longpkg}   Full package path, eg. github.com/go-logging
+//     %{shortpkg}  Base package path, eg. go-logging
+//     %{longfunc}  Full function name, eg. littleEndian.PutUint32
+//     %{shortfunc} Base function name, eg. PutUint32
+//     %{callpath}  Call function path, eg. main.a.b.c
+func NewStringFormatter(format string) (Formatter, error) {
+	var fmter = &stringFormatter{}
+
+	// Find the boundaries of all %{vars}
+	matches := formatRe.FindAllStringSubmatchIndex(format, -1)
+	if matches == nil {
+		return nil, errors.New("logger: invalid log format: " + format)
+	}
+
+	// Collect all variables and static text for the format
+	prev := 0
+	for _, m := range matches {
+		start, end := m[0], m[1]
+		if start > prev {
+			fmter.add(fmtVerbStatic, format[prev:start])
+		}
+
+		name := format[m[2]:m[3]]
+		verb := getFmtVerbByName(name)
+		if verb == fmtVerbUnknown {
+			return nil, errors.New("logger: unknown variable: " + name)
+		}
+
+		// Handle layout customizations or use the default. If this is not for the
+		// time, color formatting or callpath, we need to prefix with %.
+		layout := defaultVerbsLayout[verb]
+		if m[4] != -1 {
+			layout = format[m[4]:m[5]]
+		}
+		if verb != fmtVerbTime && verb != fmtVerbLevelColor && verb != fmtVerbCallpath {
+			layout = "%" + layout
+		}
+
+		fmter.add(verb, layout)
+		prev = end
+	}
+	end := format[prev:]
+	if end != "" {
+		fmter.add(fmtVerbStatic, end)
+	}
+
+	// Make a test run to make sure we can format it correctly.
+	t, err := time.Parse(time.RFC3339, "2010-02-04T21:00:57-08:00")
+	if err != nil {
+		panic(err)
+	}
+	testFmt := "hello %s"
+	r := &Record{
+		ID:     12345,
+		Time:   t,
+		Module: "logger",
+		Args:   []interface{}{"go"},
+		fmt:    &testFmt,
+	}
+	if err := fmter.Format(0, r, &bytes.Buffer{}); err != nil {
+		return nil, err
+	}
+
+	return fmter, nil
+}
+
+// MustStringFormatter is equivalent to NewStringFormatter with a call to panic
+// on error.
+func MustStringFormatter(format string) Formatter {
+	f, err := NewStringFormatter(format)
+	if err != nil {
+		panic("Failed to initialized string formatter: " + err.Error())
+	}
+	return f
+}
+
+func (f *stringFormatter) add(verb fmtVerb, layout string) {
+	f.parts = append(f.parts, part{verb, layout})
+}
+
+func (f *stringFormatter) Format(calldepth int, r *Record, output io.Writer) error {
+	for _, part := range f.parts {
+		if part.verb == fmtVerbStatic {
+			output.Write([]byte(part.layout))
+		} else if part.verb == fmtVerbTime {
+			output.Write([]byte(r.Time.Format(part.layout)))
+		} else if part.verb == fmtVerbLevelColor {
+			doFmtVerbLevelColor(part.layout, r.Level, output)
+		} else if part.verb == fmtVerbCallpath {
+			depth, err := strconv.Atoi(part.layout)
+			if err != nil {
+				depth = 0
+			}
+			output.Write([]byte(formatCallpath(calldepth+1, depth)))
+		} else {
+			var v interface{}
+			switch part.verb {
+			case fmtVerbLevel:
+				v = r.Level
+				break
+			case fmtVerbID:
+				v = r.ID
+				break
+			case fmtVerbPid:
+				v = pid
+				break
+			case fmtVerbProgram:
+				v = program
+				break
+			case fmtVerbModule:
+				v = r.Module
+				break
+			case fmtVerbMessage:
+				v = r.Message()
+				break
+			case fmtVerbLongfile, fmtVerbShortfile:
+				_, file, line, ok := runtime.Caller(calldepth + 1)
+				if !ok {
+					file = "???"
+					line = 0
+				} else if part.verb == fmtVerbShortfile {
+					file = filepath.Base(file)
+				}
+				v = fmt.Sprintf("%s:%d", file, line)
+			case fmtVerbLongfunc, fmtVerbShortfunc,
+				fmtVerbLongpkg, fmtVerbShortpkg:
+				// TODO cache pc
+				v = "???"
+				if pc, _, _, ok := runtime.Caller(calldepth + 1); ok {
+					if f := runtime.FuncForPC(pc); f != nil {
+						v = formatFuncName(part.verb, f.Name())
+					}
+				}
+			default:
+				panic("unhandled format part")
+			}
+			fmt.Fprintf(output, part.layout, v)
+		}
+	}
+	return nil
+}
+
+// formatFuncName tries to extract certain part of the runtime formatted
+// function name to some pre-defined variation.
+//
+// This function is known to not work properly if the package path or name
+// contains a dot.
+func formatFuncName(v fmtVerb, f string) string {
+	i := strings.LastIndex(f, "/")
+	j := strings.Index(f[i+1:], ".")
+	if j < 1 {
+		return "???"
+	}
+	pkg, fun := f[:i+j+1], f[i+j+2:]
+	switch v {
+	case fmtVerbLongpkg:
+		return pkg
+	case fmtVerbShortpkg:
+		return path.Base(pkg)
+	case fmtVerbLongfunc:
+		return fun
+	case fmtVerbShortfunc:
+		i = strings.LastIndex(fun, ".")
+		return fun[i+1:]
+	}
+	panic("unexpected func formatter")
+}
+
+func formatCallpath(calldepth int, depth int) string {
+	v := ""
+	callers := make([]uintptr, 64)
+	n := runtime.Callers(calldepth+2, callers)
+	oldPc := callers[n-1]
+
+	start := n - 3
+	if depth > 0 && start >= depth {
+		start = depth - 1
+		v += "~."
+	}
+	recursiveCall := false
+	for i := start; i >= 0; i-- {
+		pc := callers[i]
+		if oldPc == pc {
+			recursiveCall = true
+			continue
+		}
+		oldPc = pc
+		if recursiveCall {
+			recursiveCall = false
+			v += ".."
+		}
+		if i < start {
+			v += "."
+		}
+		if f := runtime.FuncForPC(pc); f != nil {
+			v += formatFuncName(fmtVerbShortfunc, f.Name())
+		}
+	}
+	return v
+}
+
+// backendFormatter combines a backend with a specific formatter making it
+// possible to have different log formats for different backends.
+type backendFormatter struct {
+	b Backend
+	f Formatter
+}
+
+// NewBackendFormatter creates a new backend which makes all records that
+// passes through it beeing formatted by the specific formatter.
+func NewBackendFormatter(b Backend, f Formatter) Backend {
+	return &backendFormatter{b, f}
+}
+
+// Log implements the Log function required by the Backend interface.
+func (bf *backendFormatter) Log(level Level, calldepth int, r *Record) error {
+	// Make a shallow copy of the record and replace any formatter
+	r2 := *r
+	r2.formatter = bf.f
+	return bf.b.Log(level, calldepth+1, &r2)
+}

--- a/gregord/vendor/github.com/keybase/go-logging/level.go
+++ b/gregord/vendor/github.com/keybase/go-logging/level.go
@@ -1,0 +1,134 @@
+// Copyright 2013, Örjan Persson. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package logging
+
+import (
+	"errors"
+	"strings"
+	"sync"
+)
+
+// ErrInvalidLogLevel is used when an invalid log level has been used.
+var ErrInvalidLogLevel = errors.New("logger: invalid log level")
+
+// Level defines all available log levels for log messages.
+type Level int
+
+// Log levels.
+const (
+	CRITICAL Level = iota
+	ERROR
+	WARNING
+	NOTICE
+	INFO
+	DEBUG
+)
+
+var levelNames = []string{
+	"CRITICAL",
+	"ERROR",
+	"WARNING",
+	"NOTICE",
+	"INFO",
+	"DEBUG",
+}
+
+// String returns the string representation of a logging level.
+func (p Level) String() string {
+	return levelNames[p]
+}
+
+// LogLevel returns the log level from a string representation.
+func LogLevel(level string) (Level, error) {
+	for i, name := range levelNames {
+		if strings.EqualFold(name, level) {
+			return Level(i), nil
+		}
+	}
+	return ERROR, ErrInvalidLogLevel
+}
+
+// Leveled interface is the interface required to be able to add leveled
+// logging.
+type Leveled interface {
+	GetLevel(string) Level
+	SetLevel(Level, string)
+	IsEnabledFor(Level, string) bool
+}
+
+// LeveledBackend is a log backend with additional knobs for setting levels on
+// individual modules to different levels.
+type LeveledBackend interface {
+	Backend
+	Leveled
+}
+
+type moduleLeveled struct {
+	levels    map[string]Level
+	backend   Backend
+	formatter Formatter
+	once      sync.Once
+	mutex     sync.Mutex
+}
+
+// AddModuleLevel wraps a log backend with knobs to have different log levels
+// for different modules.
+func AddModuleLevel(backend Backend) LeveledBackend {
+	var leveled LeveledBackend
+	var ok bool
+	if leveled, ok = backend.(LeveledBackend); !ok {
+		leveled = &moduleLeveled{
+			levels:  make(map[string]Level),
+			backend: backend,
+			mutex:   sync.Mutex{},
+		}
+	}
+	return leveled
+}
+
+// GetLevel returns the log level for the given module.
+func (l *moduleLeveled) GetLevel(module string) Level {
+	l.mutex.Lock()
+	level, exists := l.levels[module]
+	if exists == false {
+		level, exists = l.levels[""]
+		// no configuration exists, default to debug
+		if exists == false {
+			level = DEBUG
+		}
+	}
+	l.mutex.Unlock()
+	return level
+}
+
+// SetLevel sets the log level for the given module.
+func (l *moduleLeveled) SetLevel(level Level, module string) {
+	l.mutex.Lock()
+	l.levels[module] = level
+	l.mutex.Unlock()
+}
+
+// IsEnabledFor will return true if logging is enabled for the given module.
+func (l *moduleLeveled) IsEnabledFor(level Level, module string) bool {
+	return level <= l.GetLevel(module)
+}
+
+func (l *moduleLeveled) Log(level Level, calldepth int, rec *Record) (err error) {
+	if l.IsEnabledFor(level, rec.Module) {
+		// TODO get rid of traces of formatter here. BackendFormatter should be used.
+		rec.formatter = l.getFormatterAndCacheCurrent()
+		err = l.backend.Log(level, calldepth+1, rec)
+	}
+	return
+}
+
+func (l *moduleLeveled) getFormatterAndCacheCurrent() Formatter {
+	l.once.Do(func() {
+		if l.formatter == nil {
+			l.formatter = getFormatter()
+		}
+	})
+	return l.formatter
+}

--- a/gregord/vendor/github.com/keybase/go-logging/log.go
+++ b/gregord/vendor/github.com/keybase/go-logging/log.go
@@ -1,0 +1,58 @@
+// Copyright 2013, Örjan Persson. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package logging
+
+import (
+	"fmt"
+	"io"
+)
+
+type color int
+
+const (
+	colorBlack = iota + 30
+	colorRed
+	colorGreen
+	colorYellow
+	colorBlue
+	colorMagenta
+	colorCyan
+	colorWhite
+)
+
+var (
+	colors = []string{
+		CRITICAL: colorSeq(colorMagenta),
+		ERROR:    colorSeq(colorRed),
+		WARNING:  colorSeq(colorYellow),
+		NOTICE:   colorSeq(colorGreen),
+		DEBUG:    colorSeq(colorCyan),
+	}
+	boldcolors = []string{
+		CRITICAL: colorSeqBold(colorMagenta),
+		ERROR:    colorSeqBold(colorRed),
+		WARNING:  colorSeqBold(colorYellow),
+		NOTICE:   colorSeqBold(colorGreen),
+		DEBUG:    colorSeqBold(colorCyan),
+	}
+)
+
+func colorSeq(color color) string {
+	return fmt.Sprintf("\033[%dm", int(color))
+}
+
+func colorSeqBold(color color) string {
+	return fmt.Sprintf("\033[%d;1m", int(color))
+}
+
+func doFmtVerbLevelColor(layout string, level Level, output io.Writer) {
+	if layout == "bold" {
+		output.Write([]byte(boldcolors[level]))
+	} else if layout == "reset" {
+		output.Write([]byte("\033[0m"))
+	} else {
+		output.Write([]byte(colors[level]))
+	}
+}

--- a/gregord/vendor/github.com/keybase/go-logging/log_nix.go
+++ b/gregord/vendor/github.com/keybase/go-logging/log_nix.go
@@ -1,0 +1,46 @@
+// +build !windows
+
+// Copyright 2013, Örjan Persson. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package logging
+
+import (
+	"bytes"
+	"io"
+	"log"
+)
+
+// LogBackend utilizes the standard log module.
+type LogBackend struct {
+	Logger      *log.Logger
+	Color       bool
+	ColorConfig []string
+}
+
+// NewLogBackend creates a new LogBackend.
+func NewLogBackend(out io.Writer, prefix string, flag int) *LogBackend {
+	return &LogBackend{Logger: log.New(out, prefix, flag)}
+}
+
+// Log implements the Backend interface.
+func (b *LogBackend) Log(level Level, calldepth int, rec *Record) error {
+	if b.Color {
+		col := colors[level]
+		if len(b.ColorConfig) > int(level) && b.ColorConfig[level] != "" {
+			col = b.ColorConfig[level]
+		}
+
+		buf := &bytes.Buffer{}
+		buf.Write([]byte(col))
+		buf.Write([]byte(rec.Formatted(calldepth + 1)))
+		buf.Write([]byte("\033[0m"))
+		// For some reason, the Go logger arbitrarily decided "2" was the correct
+		// call depth...
+		return b.Logger.Output(calldepth+2, buf.String())
+	}
+
+	return b.Logger.Output(calldepth+2, rec.Formatted(calldepth+1))
+}
+

--- a/gregord/vendor/github.com/keybase/go-logging/log_windows.go
+++ b/gregord/vendor/github.com/keybase/go-logging/log_windows.go
@@ -1,0 +1,104 @@
+// +build windows
+// Copyright 2013, Örjan Persson. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package logging
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"syscall"
+)
+
+var (
+	kernel32DLL                 = syscall.NewLazyDLL("kernel32.dll")
+	setConsoleTextAttributeProc = kernel32DLL.NewProc("SetConsoleTextAttribute")
+)
+
+type WORD uint16
+
+// Character attributes
+// Note:
+// -- The attributes are combined to produce various colors (e.g., Blue + Green will create Cyan).
+//    Clearing all foreground or background colors results in black; setting all creates white.
+// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms682088(v=vs.85).aspx#_win32_character_attributes.
+const (
+	fgBlack     = 0x0000
+	fgBlue      = 0x0001
+	fgGreen     = 0x0002
+	fgCyan      = 0x0003
+	fgRed       = 0x0004
+	fgMagenta   = 0x0005
+	fgYellow    = 0x0006
+	fgWhite     = 0x0007
+	fgIntensity = 0x0008
+	fgMask      = 0x000F
+)
+
+var (
+	win_colors = []uint16{
+		INFO:     fgWhite,
+		CRITICAL: fgMagenta,
+		ERROR:    fgRed,
+		WARNING:  fgYellow,
+		NOTICE:   fgGreen,
+		DEBUG:    fgCyan,
+	}
+	win_boldcolors = []uint16{
+		INFO:     fgWhite | fgIntensity,
+		CRITICAL: fgMagenta | fgIntensity,
+		ERROR:    fgRed | fgIntensity,
+		WARNING:  fgYellow | fgIntensity,
+		NOTICE:   fgGreen | fgIntensity,
+		DEBUG:    fgCyan | fgIntensity,
+	}
+)
+
+type file interface {
+	Fd() uintptr
+}
+
+// LogBackend utilizes the standard log module.
+type LogBackend struct {
+	Logger *log.Logger
+	Color  bool
+
+	// f is set to a non-nil value if the underlying writer which logs writes to
+	// implements the file interface. This makes us able to colorise the output.
+	f file
+}
+
+// NewLogBackend creates a new LogBackend.
+func NewLogBackend(out io.Writer, prefix string, flag int) *LogBackend {
+	b := &LogBackend{Logger: log.New(out, prefix, flag)}
+
+	// Unfortunately, the API used only takes an io.Writer where the Windows API
+	// need the actual fd to change colors.
+	if f, ok := out.(file); ok {
+		b.f = f
+	}
+
+	return b
+}
+
+func (b *LogBackend) Log(level Level, calldepth int, rec *Record) error {
+	if b.Color && b.f != nil {
+		buf := &bytes.Buffer{}
+		setConsoleTextAttribute(b.f, win_colors[level])
+		buf.Write([]byte(rec.Formatted(calldepth + 1)))
+		err := b.Logger.Output(calldepth+2, buf.String())
+		setConsoleTextAttribute(b.f, fgWhite)
+		return err
+	}
+	return b.Logger.Output(calldepth+2, rec.Formatted(calldepth+1))
+}
+
+// setConsoleTextAttribute sets the attributes of characters written to the
+// console screen buffer by the WriteFile or WriteConsole function.
+// See http://msdn.microsoft.com/en-us/library/windows/desktop/ms686047(v=vs.85).aspx.
+func setConsoleTextAttribute(f file, attribute uint16) bool {
+	ok, _, _ := setConsoleTextAttributeProc.Call(f.Fd(), uintptr(attribute), 0)
+	return ok != 0
+}

--- a/gregord/vendor/github.com/keybase/go-logging/logger.go
+++ b/gregord/vendor/github.com/keybase/go-logging/logger.go
@@ -1,0 +1,261 @@
+// Copyright 2013, Örjan Persson. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package logging implements a logging infrastructure for Go. It supports
+// different logging backends like syslog, file and memory. Multiple backends
+// can be utilized with different log levels per backend and logger.
+package logging
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// Redactor is an interface for types that may contain sensitive information
+// (like passwords), which shouldn't be printed to the log. The idea was found
+// in relog as part of the vitness project.
+type Redactor interface {
+	Redacted() interface{}
+}
+
+// Redact returns a string of * having the same length as s.
+func Redact(s string) string {
+	return strings.Repeat("*", len(s))
+}
+
+var (
+	// Sequence number is incremented and utilized for all log records created.
+	sequenceNo uint64
+
+	// timeNow is a customizable for testing purposes.
+	timeNow = time.Now
+)
+
+// Record represents a log record and contains the timestamp when the record
+// was created, an increasing id, filename and line and finally the actual
+// formatted log line.
+type Record struct {
+	ID     uint64
+	Time   time.Time
+	Module string
+	Level  Level
+	Args   []interface{}
+
+	// message is kept as a pointer to have shallow copies update this once
+	// needed.
+	message   *string
+	fmt       *string
+	formatter Formatter
+	formatted string
+}
+
+// Formatted returns the formatted log record string.
+func (r *Record) Formatted(calldepth int) string {
+	if r.formatted == "" {
+		var buf bytes.Buffer
+		r.formatter.Format(calldepth+1, r, &buf)
+		r.formatted = buf.String()
+	}
+	return r.formatted
+}
+
+// Message returns the log record message.
+func (r *Record) Message() string {
+	if r.message == nil {
+		// Redact the arguments that implements the Redactor interface
+		for i, arg := range r.Args {
+			if redactor, ok := arg.(Redactor); ok == true {
+				r.Args[i] = redactor.Redacted()
+			}
+		}
+		var buf bytes.Buffer
+		if r.fmt != nil {
+			fmt.Fprintf(&buf, *r.fmt, r.Args...)
+		} else {
+			// use Fprintln to make sure we always get space between arguments
+			fmt.Fprintln(&buf, r.Args...)
+			buf.Truncate(buf.Len() - 1) // strip newline
+		}
+		msg := buf.String()
+		r.message = &msg
+	}
+	return *r.message
+}
+
+// Logger is the actual logger which creates log records based on the functions
+// called and passes them to the underlying logging backend.
+type Logger struct {
+	Module      string
+	backend     LeveledBackend
+	haveBackend bool
+
+	// ExtraCallDepth can be used to add additional call depth when getting the
+	// calling function. This is normally used when wrapping a logger.
+	ExtraCalldepth int
+}
+
+// SetBackend overrides any previously defined backend for this logger.
+func (l *Logger) SetBackend(backend LeveledBackend) {
+	l.backend = backend
+	l.haveBackend = true
+}
+
+// TODO call NewLogger and remove MustGetLogger?
+
+// GetLogger creates and returns a Logger object based on the module name.
+func GetLogger(module string) (*Logger, error) {
+	return &Logger{Module: module}, nil
+}
+
+// MustGetLogger is like GetLogger but panics if the logger can't be created.
+// It simplifies safe initialization of a global logger for eg. a package.
+func MustGetLogger(module string) *Logger {
+	logger, err := GetLogger(module)
+	if err != nil {
+		panic("logger: " + module + ": " + err.Error())
+	}
+	return logger
+}
+
+// Reset restores the internal state of the logging library.
+func Reset() {
+	// TODO make a global Init() method to be less magic? or make it such that
+	// if there's no backends at all configured, we could use some tricks to
+	// automatically setup backends based if we have a TTY or not.
+	sequenceNo = 0
+	b := SetBackend(NewLogBackend(os.Stderr, "", log.LstdFlags))
+	b.SetLevel(DEBUG, "")
+	SetFormatter(DefaultFormatter)
+	timeNow = time.Now
+}
+
+// IsEnabledFor returns true if the logger is enabled for the given level.
+func (l *Logger) IsEnabledFor(level Level) bool {
+	return defaultBackend.IsEnabledFor(level, l.Module)
+}
+
+func (l *Logger) log(lvl Level, format *string, args ...interface{}) {
+	if !l.IsEnabledFor(lvl) {
+		return
+	}
+
+	// Create the logging record and pass it in to the backend
+	record := &Record{
+		ID:     atomic.AddUint64(&sequenceNo, 1),
+		Time:   timeNow(),
+		Module: l.Module,
+		Level:  lvl,
+		fmt:    format,
+		Args:   args,
+	}
+
+	// TODO use channels to fan out the records to all backends?
+	// TODO in case of errors, do something (tricky)
+
+	// calldepth=2 brings the stack up to the caller of the level
+	// methods, Info(), Fatal(), etc.
+	// ExtraCallDepth allows this to be extended further up the stack in case we
+	// are wrapping these methods, eg. to expose them package level
+	if l.haveBackend {
+		l.backend.Log(lvl, 2+l.ExtraCalldepth, record)
+		return
+	}
+
+	defaultBackendMutex.Lock()
+	defaultBackend.Log(lvl, 2+l.ExtraCalldepth, record)
+	defaultBackendMutex.Unlock()
+}
+
+// Fatal is equivalent to l.Critical(fmt.Sprint()) followed by a call to os.Exit(1).
+func (l *Logger) Fatal(args ...interface{}) {
+	l.log(CRITICAL, nil, args...)
+	os.Exit(1)
+}
+
+// Fatalf is equivalent to l.Critical followed by a call to os.Exit(1).
+func (l *Logger) Fatalf(format string, args ...interface{}) {
+	l.log(CRITICAL, &format, args...)
+	os.Exit(1)
+}
+
+// Panic is equivalent to l.Critical(fmt.Sprint()) followed by a call to panic().
+func (l *Logger) Panic(args ...interface{}) {
+	l.log(CRITICAL, nil, args...)
+	panic(fmt.Sprint(args...))
+}
+
+// Panicf is equivalent to l.Critical followed by a call to panic().
+func (l *Logger) Panicf(format string, args ...interface{}) {
+	l.log(CRITICAL, &format, args...)
+	panic(fmt.Sprintf(format, args...))
+}
+
+// Critical logs a message using CRITICAL as log level.
+func (l *Logger) Critical(args ...interface{}) {
+	l.log(CRITICAL, nil, args...)
+}
+
+// Criticalf logs a message using CRITICAL as log level.
+func (l *Logger) Criticalf(format string, args ...interface{}) {
+	l.log(CRITICAL, &format, args...)
+}
+
+// Error logs a message using ERROR as log level.
+func (l *Logger) Error(args ...interface{}) {
+	l.log(ERROR, nil, args...)
+}
+
+// Errorf logs a message using ERROR as log level.
+func (l *Logger) Errorf(format string, args ...interface{}) {
+	l.log(ERROR, &format, args...)
+}
+
+// Warning logs a message using WARNING as log level.
+func (l *Logger) Warning(args ...interface{}) {
+	l.log(WARNING, nil, args...)
+}
+
+// Warningf logs a message using WARNING as log level.
+func (l *Logger) Warningf(format string, args ...interface{}) {
+	l.log(WARNING, &format, args...)
+}
+
+// Notice logs a message using NOTICE as log level.
+func (l *Logger) Notice(args ...interface{}) {
+	l.log(NOTICE, nil, args...)
+}
+
+// Noticef logs a message using NOTICE as log level.
+func (l *Logger) Noticef(format string, args ...interface{}) {
+	l.log(NOTICE, &format, args...)
+}
+
+// Info logs a message using INFO as log level.
+func (l *Logger) Info(args ...interface{}) {
+	l.log(INFO, nil, args...)
+}
+
+// Infof logs a message using INFO as log level.
+func (l *Logger) Infof(format string, args ...interface{}) {
+	l.log(INFO, &format, args...)
+}
+
+// Debug logs a message using DEBUG as log level.
+func (l *Logger) Debug(args ...interface{}) {
+	l.log(DEBUG, nil, args...)
+}
+
+// Debugf logs a message using DEBUG as log level.
+func (l *Logger) Debugf(format string, args ...interface{}) {
+	l.log(DEBUG, &format, args...)
+}
+
+func init() {
+	Reset()
+}

--- a/gregord/vendor/github.com/keybase/go-logging/memory.go
+++ b/gregord/vendor/github.com/keybase/go-logging/memory.go
@@ -1,0 +1,237 @@
+// Copyright 2013, Örjan Persson. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !appengine
+
+package logging
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+)
+
+// TODO pick one of the memory backends and stick with it or share interface.
+
+// InitForTesting is a convenient method when using logging in a test. Once
+// called, the time will be frozen to January 1, 1970 UTC.
+func InitForTesting(level Level) *MemoryBackend {
+	Reset()
+
+	memoryBackend := NewMemoryBackend(10240)
+
+	leveledBackend := AddModuleLevel(memoryBackend)
+	leveledBackend.SetLevel(level, "")
+	SetBackend(leveledBackend)
+
+	timeNow = func() time.Time {
+		return time.Unix(0, 0).UTC()
+	}
+	return memoryBackend
+}
+
+// Node is a record node pointing to an optional next node.
+type node struct {
+	next   *node
+	Record *Record
+}
+
+// Next returns the next record node. If there's no node available, it will
+// return nil.
+func (n *node) Next() *node {
+	return n.next
+}
+
+// MemoryBackend is a simple memory based logging backend that will not produce
+// any output but merly keep records, up to the given size, in memory.
+type MemoryBackend struct {
+	size       int32
+	maxSize    int32
+	head, tail unsafe.Pointer
+}
+
+// NewMemoryBackend creates a simple in-memory logging backend.
+func NewMemoryBackend(size int) *MemoryBackend {
+	return &MemoryBackend{maxSize: int32(size)}
+}
+
+// Log implements the Log method required by Backend.
+func (b *MemoryBackend) Log(level Level, calldepth int, rec *Record) error {
+	var size int32
+
+	n := &node{Record: rec}
+	np := unsafe.Pointer(n)
+
+	// Add the record to the tail. If there's no records available, tail and
+	// head will both be nil. When we successfully set the tail and the previous
+	// value was nil, it's safe to set the head to the current value too.
+	for {
+		tailp := b.tail
+		swapped := atomic.CompareAndSwapPointer(
+			&b.tail,
+			tailp,
+			np,
+		)
+		if swapped == true {
+			if tailp == nil {
+				b.head = np
+			} else {
+				(*node)(tailp).next = n
+			}
+			size = atomic.AddInt32(&b.size, 1)
+			break
+		}
+	}
+
+	// Since one record was added, we might have overflowed the list. Remove
+	// a record if that is the case. The size will fluctate a bit, but
+	// eventual consistent.
+	if b.maxSize > 0 && size > b.maxSize {
+		for {
+			headp := b.head
+			head := (*node)(b.head)
+			if head.next == nil {
+				break
+			}
+			swapped := atomic.CompareAndSwapPointer(
+				&b.head,
+				headp,
+				unsafe.Pointer(head.next),
+			)
+			if swapped == true {
+				atomic.AddInt32(&b.size, -1)
+				break
+			}
+		}
+	}
+	return nil
+}
+
+// Head returns the oldest record node kept in memory. It can be used to
+// iterate over records, one by one, up to the last record.
+//
+// Note: new records can get added while iterating. Hence the number of records
+// iterated over might be larger than the maximum size.
+func (b *MemoryBackend) Head() *node {
+	return (*node)(b.head)
+}
+
+type event int
+
+const (
+	eventFlush event = iota
+	eventStop
+)
+
+// ChannelMemoryBackend is very similar to the MemoryBackend, except that it
+// internally utilizes a channel.
+type ChannelMemoryBackend struct {
+	maxSize    int
+	size       int
+	incoming   chan *Record
+	events     chan event
+	mu         sync.Mutex
+	running    bool
+	flushWg    sync.WaitGroup
+	stopWg     sync.WaitGroup
+	head, tail *node
+}
+
+// NewChannelMemoryBackend creates a simple in-memory logging backend which
+// utilizes a go channel for communication.
+//
+// Start will automatically be called by this function.
+func NewChannelMemoryBackend(size int) *ChannelMemoryBackend {
+	backend := &ChannelMemoryBackend{
+		maxSize:  size,
+		incoming: make(chan *Record, 1024),
+		events:   make(chan event),
+	}
+	backend.Start()
+	return backend
+}
+
+// Start launches the internal goroutine which starts processing data from the
+// input channel.
+func (b *ChannelMemoryBackend) Start() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// Launch the goroutine unless it's already running.
+	if b.running != true {
+		b.running = true
+		b.stopWg.Add(1)
+		go b.process()
+	}
+}
+
+func (b *ChannelMemoryBackend) process() {
+	defer b.stopWg.Done()
+	for {
+		select {
+		case rec := <-b.incoming:
+			b.insertRecord(rec)
+		case e := <-b.events:
+			switch e {
+			case eventStop:
+				return
+			case eventFlush:
+				for len(b.incoming) > 0 {
+					b.insertRecord(<-b.incoming)
+				}
+				b.flushWg.Done()
+			}
+		}
+	}
+}
+
+func (b *ChannelMemoryBackend) insertRecord(rec *Record) {
+	prev := b.tail
+	b.tail = &node{Record: rec}
+	if prev == nil {
+		b.head = b.tail
+	} else {
+		prev.next = b.tail
+	}
+
+	if b.maxSize > 0 && b.size >= b.maxSize {
+		b.head = b.head.next
+	} else {
+		b.size++
+	}
+}
+
+// Flush waits until all records in the buffered channel have been processed.
+func (b *ChannelMemoryBackend) Flush() {
+	b.flushWg.Add(1)
+	b.events <- eventFlush
+	b.flushWg.Wait()
+}
+
+// Stop signals the internal goroutine to exit and waits until it have.
+func (b *ChannelMemoryBackend) Stop() {
+	b.mu.Lock()
+	if b.running == true {
+		b.running = false
+		b.events <- eventStop
+	}
+	b.mu.Unlock()
+	b.stopWg.Wait()
+}
+
+// Log implements the Log method required by Backend.
+func (b *ChannelMemoryBackend) Log(level Level, calldepth int, rec *Record) error {
+	b.incoming <- rec
+	return nil
+}
+
+// Head returns the oldest record node kept in memory. It can be used to
+// iterate over records, one by one, up to the last record.
+//
+// Note: new records can get added while iterating. Hence the number of records
+// iterated over might be larger than the maximum size.
+func (b *ChannelMemoryBackend) Head() *node {
+	return b.head
+}

--- a/gregord/vendor/github.com/keybase/go-logging/multi.go
+++ b/gregord/vendor/github.com/keybase/go-logging/multi.go
@@ -1,0 +1,65 @@
+// Copyright 2013, Örjan Persson. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package logging
+
+// TODO remove Level stuff from the multi logger. Do one thing.
+
+// multiLogger is a log multiplexer which can be used to utilize multiple log
+// backends at once.
+type multiLogger struct {
+	backends []LeveledBackend
+}
+
+// MultiLogger creates a logger which contain multiple loggers.
+func MultiLogger(backends ...Backend) LeveledBackend {
+	var leveledBackends []LeveledBackend
+	for _, backend := range backends {
+		leveledBackends = append(leveledBackends, AddModuleLevel(backend))
+	}
+	return &multiLogger{leveledBackends}
+}
+
+// Log passes the log record to all backends.
+func (b *multiLogger) Log(level Level, calldepth int, rec *Record) (err error) {
+	for _, backend := range b.backends {
+		if backend.IsEnabledFor(level, rec.Module) {
+			// Shallow copy of the record for the formatted cache on Record and get the
+			// record formatter from the backend.
+			r2 := *rec
+			if e := backend.Log(level, calldepth+1, &r2); e != nil {
+				err = e
+			}
+		}
+	}
+	return
+}
+
+// GetLevel returns the highest level enabled by all backends.
+func (b *multiLogger) GetLevel(module string) Level {
+	var level Level
+	for _, backend := range b.backends {
+		if backendLevel := backend.GetLevel(module); backendLevel > level {
+			level = backendLevel
+		}
+	}
+	return level
+}
+
+// SetLevel propagates the same level to all backends.
+func (b *multiLogger) SetLevel(level Level, module string) {
+	for _, backend := range b.backends {
+		backend.SetLevel(level, module)
+	}
+}
+
+// IsEnabledFor returns true if any of the backends are enabled for it.
+func (b *multiLogger) IsEnabledFor(level Level, module string) bool {
+	for _, backend := range b.backends {
+		if backend.IsEnabledFor(level, module) {
+			return true
+		}
+	}
+	return false
+}

--- a/gregord/vendor/github.com/keybase/go-logging/syslog.go
+++ b/gregord/vendor/github.com/keybase/go-logging/syslog.go
@@ -1,0 +1,53 @@
+// Copyright 2013, Örjan Persson. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//+build !windows,!plan9
+
+package logging
+
+import "log/syslog"
+
+// SyslogBackend is a simple logger to syslog backend. It automatically maps
+// the internal log levels to appropriate syslog log levels.
+type SyslogBackend struct {
+	Writer *syslog.Writer
+}
+
+// NewSyslogBackend connects to the syslog daemon using UNIX sockets with the
+// given prefix. If prefix is not given, the prefix will be derived from the
+// launched command.
+func NewSyslogBackend(prefix string) (b *SyslogBackend, err error) {
+	var w *syslog.Writer
+	w, err = syslog.New(syslog.LOG_CRIT, prefix)
+	return &SyslogBackend{w}, err
+}
+
+// NewSyslogBackendPriority is the same as NewSyslogBackend, but with custom
+// syslog priority, like syslog.LOG_LOCAL3|syslog.LOG_DEBUG etc.
+func NewSyslogBackendPriority(prefix string, priority syslog.Priority) (b *SyslogBackend, err error) {
+	var w *syslog.Writer
+	w, err = syslog.New(priority, prefix)
+	return &SyslogBackend{w}, err
+}
+
+// Log implements the Backend interface.
+func (b *SyslogBackend) Log(level Level, calldepth int, rec *Record) error {
+	line := rec.Formatted(calldepth + 1)
+	switch level {
+	case CRITICAL:
+		return b.Writer.Crit(line)
+	case ERROR:
+		return b.Writer.Err(line)
+	case WARNING:
+		return b.Writer.Warning(line)
+	case NOTICE:
+		return b.Writer.Notice(line)
+	case INFO:
+		return b.Writer.Info(line)
+	case DEBUG:
+		return b.Writer.Debug(line)
+	default:
+	}
+	panic("unhandled log level")
+}

--- a/gregord/vendor/github.com/keybase/go-logging/syslog_fallback.go
+++ b/gregord/vendor/github.com/keybase/go-logging/syslog_fallback.go
@@ -1,0 +1,28 @@
+// Copyright 2013, Örjan Persson. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//+build windows plan9
+
+package logging
+
+import (
+	"fmt"
+)
+
+type Priority int
+
+type SyslogBackend struct {
+}
+
+func NewSyslogBackend(prefix string) (b *SyslogBackend, err error) {
+	return nil, fmt.Errorf("Platform does not support syslog")
+}
+
+func NewSyslogBackendPriority(prefix string, priority Priority) (b *SyslogBackend, err error) {
+	return nil, fmt.Errorf("Platform does not support syslog")
+}
+
+func (b *SyslogBackend) Log(level Level, calldepth int, rec *Record) error {
+	return fmt.Errorf("Platform does not support syslog")
+}

--- a/gregord/vendor/golang.org/x/crypto/ssh/terminal/terminal.go
+++ b/gregord/vendor/golang.org/x/crypto/ssh/terminal/terminal.go
@@ -1,0 +1,892 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package terminal
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"unicode/utf8"
+)
+
+// EscapeCodes contains escape sequences that can be written to the terminal in
+// order to achieve different styles of text.
+type EscapeCodes struct {
+	// Foreground colors
+	Black, Red, Green, Yellow, Blue, Magenta, Cyan, White []byte
+
+	// Reset all attributes
+	Reset []byte
+}
+
+var vt100EscapeCodes = EscapeCodes{
+	Black:   []byte{keyEscape, '[', '3', '0', 'm'},
+	Red:     []byte{keyEscape, '[', '3', '1', 'm'},
+	Green:   []byte{keyEscape, '[', '3', '2', 'm'},
+	Yellow:  []byte{keyEscape, '[', '3', '3', 'm'},
+	Blue:    []byte{keyEscape, '[', '3', '4', 'm'},
+	Magenta: []byte{keyEscape, '[', '3', '5', 'm'},
+	Cyan:    []byte{keyEscape, '[', '3', '6', 'm'},
+	White:   []byte{keyEscape, '[', '3', '7', 'm'},
+
+	Reset: []byte{keyEscape, '[', '0', 'm'},
+}
+
+// Terminal contains the state for running a VT100 terminal that is capable of
+// reading lines of input.
+type Terminal struct {
+	// AutoCompleteCallback, if non-null, is called for each keypress with
+	// the full input line and the current position of the cursor (in
+	// bytes, as an index into |line|). If it returns ok=false, the key
+	// press is processed normally. Otherwise it returns a replacement line
+	// and the new cursor position.
+	AutoCompleteCallback func(line string, pos int, key rune) (newLine string, newPos int, ok bool)
+
+	// Escape contains a pointer to the escape codes for this terminal.
+	// It's always a valid pointer, although the escape codes themselves
+	// may be empty if the terminal doesn't support them.
+	Escape *EscapeCodes
+
+	// lock protects the terminal and the state in this object from
+	// concurrent processing of a key press and a Write() call.
+	lock sync.Mutex
+
+	c      io.ReadWriter
+	prompt []rune
+
+	// line is the current line being entered.
+	line []rune
+	// pos is the logical position of the cursor in line
+	pos int
+	// echo is true if local echo is enabled
+	echo bool
+	// pasteActive is true iff there is a bracketed paste operation in
+	// progress.
+	pasteActive bool
+
+	// cursorX contains the current X value of the cursor where the left
+	// edge is 0. cursorY contains the row number where the first row of
+	// the current line is 0.
+	cursorX, cursorY int
+	// maxLine is the greatest value of cursorY so far.
+	maxLine int
+
+	termWidth, termHeight int
+
+	// outBuf contains the terminal data to be sent.
+	outBuf []byte
+	// remainder contains the remainder of any partial key sequences after
+	// a read. It aliases into inBuf.
+	remainder []byte
+	inBuf     [256]byte
+
+	// history contains previously entered commands so that they can be
+	// accessed with the up and down keys.
+	history stRingBuffer
+	// historyIndex stores the currently accessed history entry, where zero
+	// means the immediately previous entry.
+	historyIndex int
+	// When navigating up and down the history it's possible to return to
+	// the incomplete, initial line. That value is stored in
+	// historyPending.
+	historyPending string
+}
+
+// NewTerminal runs a VT100 terminal on the given ReadWriter. If the ReadWriter is
+// a local terminal, that terminal must first have been put into raw mode.
+// prompt is a string that is written at the start of each input line (i.e.
+// "> ").
+func NewTerminal(c io.ReadWriter, prompt string) *Terminal {
+	return &Terminal{
+		Escape:       &vt100EscapeCodes,
+		c:            c,
+		prompt:       []rune(prompt),
+		termWidth:    80,
+		termHeight:   24,
+		echo:         true,
+		historyIndex: -1,
+	}
+}
+
+const (
+	keyCtrlD     = 4
+	keyCtrlU     = 21
+	keyEnter     = '\r'
+	keyEscape    = 27
+	keyBackspace = 127
+	keyUnknown   = 0xd800 /* UTF-16 surrogate area */ + iota
+	keyUp
+	keyDown
+	keyLeft
+	keyRight
+	keyAltLeft
+	keyAltRight
+	keyHome
+	keyEnd
+	keyDeleteWord
+	keyDeleteLine
+	keyClearScreen
+	keyPasteStart
+	keyPasteEnd
+)
+
+var pasteStart = []byte{keyEscape, '[', '2', '0', '0', '~'}
+var pasteEnd = []byte{keyEscape, '[', '2', '0', '1', '~'}
+
+// bytesToKey tries to parse a key sequence from b. If successful, it returns
+// the key and the remainder of the input. Otherwise it returns utf8.RuneError.
+func bytesToKey(b []byte, pasteActive bool) (rune, []byte) {
+	if len(b) == 0 {
+		return utf8.RuneError, nil
+	}
+
+	if !pasteActive {
+		switch b[0] {
+		case 1: // ^A
+			return keyHome, b[1:]
+		case 5: // ^E
+			return keyEnd, b[1:]
+		case 8: // ^H
+			return keyBackspace, b[1:]
+		case 11: // ^K
+			return keyDeleteLine, b[1:]
+		case 12: // ^L
+			return keyClearScreen, b[1:]
+		case 23: // ^W
+			return keyDeleteWord, b[1:]
+		}
+	}
+
+	if b[0] != keyEscape {
+		if !utf8.FullRune(b) {
+			return utf8.RuneError, b
+		}
+		r, l := utf8.DecodeRune(b)
+		return r, b[l:]
+	}
+
+	if !pasteActive && len(b) >= 3 && b[0] == keyEscape && b[1] == '[' {
+		switch b[2] {
+		case 'A':
+			return keyUp, b[3:]
+		case 'B':
+			return keyDown, b[3:]
+		case 'C':
+			return keyRight, b[3:]
+		case 'D':
+			return keyLeft, b[3:]
+		case 'H':
+			return keyHome, b[3:]
+		case 'F':
+			return keyEnd, b[3:]
+		}
+	}
+
+	if !pasteActive && len(b) >= 6 && b[0] == keyEscape && b[1] == '[' && b[2] == '1' && b[3] == ';' && b[4] == '3' {
+		switch b[5] {
+		case 'C':
+			return keyAltRight, b[6:]
+		case 'D':
+			return keyAltLeft, b[6:]
+		}
+	}
+
+	if !pasteActive && len(b) >= 6 && bytes.Equal(b[:6], pasteStart) {
+		return keyPasteStart, b[6:]
+	}
+
+	if pasteActive && len(b) >= 6 && bytes.Equal(b[:6], pasteEnd) {
+		return keyPasteEnd, b[6:]
+	}
+
+	// If we get here then we have a key that we don't recognise, or a
+	// partial sequence. It's not clear how one should find the end of a
+	// sequence without knowing them all, but it seems that [a-zA-Z~] only
+	// appears at the end of a sequence.
+	for i, c := range b[0:] {
+		if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c == '~' {
+			return keyUnknown, b[i+1:]
+		}
+	}
+
+	return utf8.RuneError, b
+}
+
+// queue appends data to the end of t.outBuf
+func (t *Terminal) queue(data []rune) {
+	t.outBuf = append(t.outBuf, []byte(string(data))...)
+}
+
+var eraseUnderCursor = []rune{' ', keyEscape, '[', 'D'}
+var space = []rune{' '}
+
+func isPrintable(key rune) bool {
+	isInSurrogateArea := key >= 0xd800 && key <= 0xdbff
+	return key >= 32 && !isInSurrogateArea
+}
+
+// moveCursorToPos appends data to t.outBuf which will move the cursor to the
+// given, logical position in the text.
+func (t *Terminal) moveCursorToPos(pos int) {
+	if !t.echo {
+		return
+	}
+
+	x := visualLength(t.prompt) + pos
+	y := x / t.termWidth
+	x = x % t.termWidth
+
+	up := 0
+	if y < t.cursorY {
+		up = t.cursorY - y
+	}
+
+	down := 0
+	if y > t.cursorY {
+		down = y - t.cursorY
+	}
+
+	left := 0
+	if x < t.cursorX {
+		left = t.cursorX - x
+	}
+
+	right := 0
+	if x > t.cursorX {
+		right = x - t.cursorX
+	}
+
+	t.cursorX = x
+	t.cursorY = y
+	t.move(up, down, left, right)
+}
+
+func (t *Terminal) move(up, down, left, right int) {
+	movement := make([]rune, 3*(up+down+left+right))
+	m := movement
+	for i := 0; i < up; i++ {
+		m[0] = keyEscape
+		m[1] = '['
+		m[2] = 'A'
+		m = m[3:]
+	}
+	for i := 0; i < down; i++ {
+		m[0] = keyEscape
+		m[1] = '['
+		m[2] = 'B'
+		m = m[3:]
+	}
+	for i := 0; i < left; i++ {
+		m[0] = keyEscape
+		m[1] = '['
+		m[2] = 'D'
+		m = m[3:]
+	}
+	for i := 0; i < right; i++ {
+		m[0] = keyEscape
+		m[1] = '['
+		m[2] = 'C'
+		m = m[3:]
+	}
+
+	t.queue(movement)
+}
+
+func (t *Terminal) clearLineToRight() {
+	op := []rune{keyEscape, '[', 'K'}
+	t.queue(op)
+}
+
+const maxLineLength = 4096
+
+func (t *Terminal) setLine(newLine []rune, newPos int) {
+	if t.echo {
+		t.moveCursorToPos(0)
+		t.writeLine(newLine)
+		for i := len(newLine); i < len(t.line); i++ {
+			t.writeLine(space)
+		}
+		t.moveCursorToPos(newPos)
+	}
+	t.line = newLine
+	t.pos = newPos
+}
+
+func (t *Terminal) advanceCursor(places int) {
+	t.cursorX += places
+	t.cursorY += t.cursorX / t.termWidth
+	if t.cursorY > t.maxLine {
+		t.maxLine = t.cursorY
+	}
+	t.cursorX = t.cursorX % t.termWidth
+
+	if places > 0 && t.cursorX == 0 {
+		// Normally terminals will advance the current position
+		// when writing a character. But that doesn't happen
+		// for the last character in a line. However, when
+		// writing a character (except a new line) that causes
+		// a line wrap, the position will be advanced two
+		// places.
+		//
+		// So, if we are stopping at the end of a line, we
+		// need to write a newline so that our cursor can be
+		// advanced to the next line.
+		t.outBuf = append(t.outBuf, '\n')
+	}
+}
+
+func (t *Terminal) eraseNPreviousChars(n int) {
+	if n == 0 {
+		return
+	}
+
+	if t.pos < n {
+		n = t.pos
+	}
+	t.pos -= n
+	t.moveCursorToPos(t.pos)
+
+	copy(t.line[t.pos:], t.line[n+t.pos:])
+	t.line = t.line[:len(t.line)-n]
+	if t.echo {
+		t.writeLine(t.line[t.pos:])
+		for i := 0; i < n; i++ {
+			t.queue(space)
+		}
+		t.advanceCursor(n)
+		t.moveCursorToPos(t.pos)
+	}
+}
+
+// countToLeftWord returns then number of characters from the cursor to the
+// start of the previous word.
+func (t *Terminal) countToLeftWord() int {
+	if t.pos == 0 {
+		return 0
+	}
+
+	pos := t.pos - 1
+	for pos > 0 {
+		if t.line[pos] != ' ' {
+			break
+		}
+		pos--
+	}
+	for pos > 0 {
+		if t.line[pos] == ' ' {
+			pos++
+			break
+		}
+		pos--
+	}
+
+	return t.pos - pos
+}
+
+// countToRightWord returns then number of characters from the cursor to the
+// start of the next word.
+func (t *Terminal) countToRightWord() int {
+	pos := t.pos
+	for pos < len(t.line) {
+		if t.line[pos] == ' ' {
+			break
+		}
+		pos++
+	}
+	for pos < len(t.line) {
+		if t.line[pos] != ' ' {
+			break
+		}
+		pos++
+	}
+	return pos - t.pos
+}
+
+// visualLength returns the number of visible glyphs in s.
+func visualLength(runes []rune) int {
+	inEscapeSeq := false
+	length := 0
+
+	for _, r := range runes {
+		switch {
+		case inEscapeSeq:
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+				inEscapeSeq = false
+			}
+		case r == '\x1b':
+			inEscapeSeq = true
+		default:
+			length++
+		}
+	}
+
+	return length
+}
+
+// handleKey processes the given key and, optionally, returns a line of text
+// that the user has entered.
+func (t *Terminal) handleKey(key rune) (line string, ok bool) {
+	if t.pasteActive && key != keyEnter {
+		t.addKeyToLine(key)
+		return
+	}
+
+	switch key {
+	case keyBackspace:
+		if t.pos == 0 {
+			return
+		}
+		t.eraseNPreviousChars(1)
+	case keyAltLeft:
+		// move left by a word.
+		t.pos -= t.countToLeftWord()
+		t.moveCursorToPos(t.pos)
+	case keyAltRight:
+		// move right by a word.
+		t.pos += t.countToRightWord()
+		t.moveCursorToPos(t.pos)
+	case keyLeft:
+		if t.pos == 0 {
+			return
+		}
+		t.pos--
+		t.moveCursorToPos(t.pos)
+	case keyRight:
+		if t.pos == len(t.line) {
+			return
+		}
+		t.pos++
+		t.moveCursorToPos(t.pos)
+	case keyHome:
+		if t.pos == 0 {
+			return
+		}
+		t.pos = 0
+		t.moveCursorToPos(t.pos)
+	case keyEnd:
+		if t.pos == len(t.line) {
+			return
+		}
+		t.pos = len(t.line)
+		t.moveCursorToPos(t.pos)
+	case keyUp:
+		entry, ok := t.history.NthPreviousEntry(t.historyIndex + 1)
+		if !ok {
+			return "", false
+		}
+		if t.historyIndex == -1 {
+			t.historyPending = string(t.line)
+		}
+		t.historyIndex++
+		runes := []rune(entry)
+		t.setLine(runes, len(runes))
+	case keyDown:
+		switch t.historyIndex {
+		case -1:
+			return
+		case 0:
+			runes := []rune(t.historyPending)
+			t.setLine(runes, len(runes))
+			t.historyIndex--
+		default:
+			entry, ok := t.history.NthPreviousEntry(t.historyIndex - 1)
+			if ok {
+				t.historyIndex--
+				runes := []rune(entry)
+				t.setLine(runes, len(runes))
+			}
+		}
+	case keyEnter:
+		t.moveCursorToPos(len(t.line))
+		t.queue([]rune("\r\n"))
+		line = string(t.line)
+		ok = true
+		t.line = t.line[:0]
+		t.pos = 0
+		t.cursorX = 0
+		t.cursorY = 0
+		t.maxLine = 0
+	case keyDeleteWord:
+		// Delete zero or more spaces and then one or more characters.
+		t.eraseNPreviousChars(t.countToLeftWord())
+	case keyDeleteLine:
+		// Delete everything from the current cursor position to the
+		// end of line.
+		for i := t.pos; i < len(t.line); i++ {
+			t.queue(space)
+			t.advanceCursor(1)
+		}
+		t.line = t.line[:t.pos]
+		t.moveCursorToPos(t.pos)
+	case keyCtrlD:
+		// Erase the character under the current position.
+		// The EOF case when the line is empty is handled in
+		// readLine().
+		if t.pos < len(t.line) {
+			t.pos++
+			t.eraseNPreviousChars(1)
+		}
+	case keyCtrlU:
+		t.eraseNPreviousChars(t.pos)
+	case keyClearScreen:
+		// Erases the screen and moves the cursor to the home position.
+		t.queue([]rune("\x1b[2J\x1b[H"))
+		t.queue(t.prompt)
+		t.cursorX, t.cursorY = 0, 0
+		t.advanceCursor(visualLength(t.prompt))
+		t.setLine(t.line, t.pos)
+	default:
+		if t.AutoCompleteCallback != nil {
+			prefix := string(t.line[:t.pos])
+			suffix := string(t.line[t.pos:])
+
+			t.lock.Unlock()
+			newLine, newPos, completeOk := t.AutoCompleteCallback(prefix+suffix, len(prefix), key)
+			t.lock.Lock()
+
+			if completeOk {
+				t.setLine([]rune(newLine), utf8.RuneCount([]byte(newLine)[:newPos]))
+				return
+			}
+		}
+		if !isPrintable(key) {
+			return
+		}
+		if len(t.line) == maxLineLength {
+			return
+		}
+		t.addKeyToLine(key)
+	}
+	return
+}
+
+// addKeyToLine inserts the given key at the current position in the current
+// line.
+func (t *Terminal) addKeyToLine(key rune) {
+	if len(t.line) == cap(t.line) {
+		newLine := make([]rune, len(t.line), 2*(1+len(t.line)))
+		copy(newLine, t.line)
+		t.line = newLine
+	}
+	t.line = t.line[:len(t.line)+1]
+	copy(t.line[t.pos+1:], t.line[t.pos:])
+	t.line[t.pos] = key
+	if t.echo {
+		t.writeLine(t.line[t.pos:])
+	}
+	t.pos++
+	t.moveCursorToPos(t.pos)
+}
+
+func (t *Terminal) writeLine(line []rune) {
+	for len(line) != 0 {
+		remainingOnLine := t.termWidth - t.cursorX
+		todo := len(line)
+		if todo > remainingOnLine {
+			todo = remainingOnLine
+		}
+		t.queue(line[:todo])
+		t.advanceCursor(visualLength(line[:todo]))
+		line = line[todo:]
+	}
+}
+
+func (t *Terminal) Write(buf []byte) (n int, err error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if t.cursorX == 0 && t.cursorY == 0 {
+		// This is the easy case: there's nothing on the screen that we
+		// have to move out of the way.
+		return t.c.Write(buf)
+	}
+
+	// We have a prompt and possibly user input on the screen. We
+	// have to clear it first.
+	t.move(0 /* up */, 0 /* down */, t.cursorX /* left */, 0 /* right */)
+	t.cursorX = 0
+	t.clearLineToRight()
+
+	for t.cursorY > 0 {
+		t.move(1 /* up */, 0, 0, 0)
+		t.cursorY--
+		t.clearLineToRight()
+	}
+
+	if _, err = t.c.Write(t.outBuf); err != nil {
+		return
+	}
+	t.outBuf = t.outBuf[:0]
+
+	if n, err = t.c.Write(buf); err != nil {
+		return
+	}
+
+	t.writeLine(t.prompt)
+	if t.echo {
+		t.writeLine(t.line)
+	}
+
+	t.moveCursorToPos(t.pos)
+
+	if _, err = t.c.Write(t.outBuf); err != nil {
+		return
+	}
+	t.outBuf = t.outBuf[:0]
+	return
+}
+
+// ReadPassword temporarily changes the prompt and reads a password, without
+// echo, from the terminal.
+func (t *Terminal) ReadPassword(prompt string) (line string, err error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	oldPrompt := t.prompt
+	t.prompt = []rune(prompt)
+	t.echo = false
+
+	line, err = t.readLine()
+
+	t.prompt = oldPrompt
+	t.echo = true
+
+	return
+}
+
+// ReadLine returns a line of input from the terminal.
+func (t *Terminal) ReadLine() (line string, err error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	return t.readLine()
+}
+
+func (t *Terminal) readLine() (line string, err error) {
+	// t.lock must be held at this point
+
+	if t.cursorX == 0 && t.cursorY == 0 {
+		t.writeLine(t.prompt)
+		t.c.Write(t.outBuf)
+		t.outBuf = t.outBuf[:0]
+	}
+
+	lineIsPasted := t.pasteActive
+
+	for {
+		rest := t.remainder
+		lineOk := false
+		for !lineOk {
+			var key rune
+			key, rest = bytesToKey(rest, t.pasteActive)
+			if key == utf8.RuneError {
+				break
+			}
+			if !t.pasteActive {
+				if key == keyCtrlD {
+					if len(t.line) == 0 {
+						return "", io.EOF
+					}
+				}
+				if key == keyPasteStart {
+					t.pasteActive = true
+					if len(t.line) == 0 {
+						lineIsPasted = true
+					}
+					continue
+				}
+			} else if key == keyPasteEnd {
+				t.pasteActive = false
+				continue
+			}
+			if !t.pasteActive {
+				lineIsPasted = false
+			}
+			line, lineOk = t.handleKey(key)
+		}
+		if len(rest) > 0 {
+			n := copy(t.inBuf[:], rest)
+			t.remainder = t.inBuf[:n]
+		} else {
+			t.remainder = nil
+		}
+		t.c.Write(t.outBuf)
+		t.outBuf = t.outBuf[:0]
+		if lineOk {
+			if t.echo {
+				t.historyIndex = -1
+				t.history.Add(line)
+			}
+			if lineIsPasted {
+				err = ErrPasteIndicator
+			}
+			return
+		}
+
+		// t.remainder is a slice at the beginning of t.inBuf
+		// containing a partial key sequence
+		readBuf := t.inBuf[len(t.remainder):]
+		var n int
+
+		t.lock.Unlock()
+		n, err = t.c.Read(readBuf)
+		t.lock.Lock()
+
+		if err != nil {
+			return
+		}
+
+		t.remainder = t.inBuf[:n+len(t.remainder)]
+	}
+
+	panic("unreachable") // for Go 1.0.
+}
+
+// SetPrompt sets the prompt to be used when reading subsequent lines.
+func (t *Terminal) SetPrompt(prompt string) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	t.prompt = []rune(prompt)
+}
+
+func (t *Terminal) clearAndRepaintLinePlusNPrevious(numPrevLines int) {
+	// Move cursor to column zero at the start of the line.
+	t.move(t.cursorY, 0, t.cursorX, 0)
+	t.cursorX, t.cursorY = 0, 0
+	t.clearLineToRight()
+	for t.cursorY < numPrevLines {
+		// Move down a line
+		t.move(0, 1, 0, 0)
+		t.cursorY++
+		t.clearLineToRight()
+	}
+	// Move back to beginning.
+	t.move(t.cursorY, 0, 0, 0)
+	t.cursorX, t.cursorY = 0, 0
+
+	t.queue(t.prompt)
+	t.advanceCursor(visualLength(t.prompt))
+	t.writeLine(t.line)
+	t.moveCursorToPos(t.pos)
+}
+
+func (t *Terminal) SetSize(width, height int) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if width == 0 {
+		width = 1
+	}
+
+	oldWidth := t.termWidth
+	t.termWidth, t.termHeight = width, height
+
+	switch {
+	case width == oldWidth:
+		// If the width didn't change then nothing else needs to be
+		// done.
+		return nil
+	case len(t.line) == 0 && t.cursorX == 0 && t.cursorY == 0:
+		// If there is nothing on current line and no prompt printed,
+		// just do nothing
+		return nil
+	case width < oldWidth:
+		// Some terminals (e.g. xterm) will truncate lines that were
+		// too long when shinking. Others, (e.g. gnome-terminal) will
+		// attempt to wrap them. For the former, repainting t.maxLine
+		// works great, but that behaviour goes badly wrong in the case
+		// of the latter because they have doubled every full line.
+
+		// We assume that we are working on a terminal that wraps lines
+		// and adjust the cursor position based on every previous line
+		// wrapping and turning into two. This causes the prompt on
+		// xterms to move upwards, which isn't great, but it avoids a
+		// huge mess with gnome-terminal.
+		if t.cursorX >= t.termWidth {
+			t.cursorX = t.termWidth - 1
+		}
+		t.cursorY *= 2
+		t.clearAndRepaintLinePlusNPrevious(t.maxLine * 2)
+	case width > oldWidth:
+		// If the terminal expands then our position calculations will
+		// be wrong in the future because we think the cursor is
+		// |t.pos| chars into the string, but there will be a gap at
+		// the end of any wrapped line.
+		//
+		// But the position will actually be correct until we move, so
+		// we can move back to the beginning and repaint everything.
+		t.clearAndRepaintLinePlusNPrevious(t.maxLine)
+	}
+
+	_, err := t.c.Write(t.outBuf)
+	t.outBuf = t.outBuf[:0]
+	return err
+}
+
+type pasteIndicatorError struct{}
+
+func (pasteIndicatorError) Error() string {
+	return "terminal: ErrPasteIndicator not correctly handled"
+}
+
+// ErrPasteIndicator may be returned from ReadLine as the error, in addition
+// to valid line data. It indicates that bracketed paste mode is enabled and
+// that the returned line consists only of pasted data. Programs may wish to
+// interpret pasted data more literally than typed data.
+var ErrPasteIndicator = pasteIndicatorError{}
+
+// SetBracketedPasteMode requests that the terminal bracket paste operations
+// with markers. Not all terminals support this but, if it is supported, then
+// enabling this mode will stop any autocomplete callback from running due to
+// pastes. Additionally, any lines that are completely pasted will be returned
+// from ReadLine with the error set to ErrPasteIndicator.
+func (t *Terminal) SetBracketedPasteMode(on bool) {
+	if on {
+		io.WriteString(t.c, "\x1b[?2004h")
+	} else {
+		io.WriteString(t.c, "\x1b[?2004l")
+	}
+}
+
+// stRingBuffer is a ring buffer of strings.
+type stRingBuffer struct {
+	// entries contains max elements.
+	entries []string
+	max     int
+	// head contains the index of the element most recently added to the ring.
+	head int
+	// size contains the number of elements in the ring.
+	size int
+}
+
+func (s *stRingBuffer) Add(a string) {
+	if s.entries == nil {
+		const defaultNumEntries = 100
+		s.entries = make([]string, defaultNumEntries)
+		s.max = defaultNumEntries
+	}
+
+	s.head = (s.head + 1) % s.max
+	s.entries[s.head] = a
+	if s.size < s.max {
+		s.size++
+	}
+}
+
+// NthPreviousEntry returns the value passed to the nth previous call to Add.
+// If n is zero then the immediately prior value is returned, if one, then the
+// next most recent, and so on. If such an element doesn't exist then ok is
+// false.
+func (s *stRingBuffer) NthPreviousEntry(n int) (value string, ok bool) {
+	if n >= s.size {
+		return "", false
+	}
+	index := s.head - n
+	if index < 0 {
+		index += s.max
+	}
+	return s.entries[index], true
+}

--- a/gregord/vendor/golang.org/x/crypto/ssh/terminal/util.go
+++ b/gregord/vendor/golang.org/x/crypto/ssh/terminal/util.go
@@ -1,0 +1,128 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin dragonfly freebsd linux,!appengine netbsd openbsd
+
+// Package terminal provides support functions for dealing with terminals, as
+// commonly found on UNIX systems.
+//
+// Putting a terminal into raw mode is the most common requirement:
+//
+// 	oldState, err := terminal.MakeRaw(0)
+// 	if err != nil {
+// 	        panic(err)
+// 	}
+// 	defer terminal.Restore(0, oldState)
+package terminal // import "golang.org/x/crypto/ssh/terminal"
+
+import (
+	"io"
+	"syscall"
+	"unsafe"
+)
+
+// State contains the state of a terminal.
+type State struct {
+	termios syscall.Termios
+}
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal(fd int) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}
+
+// MakeRaw put the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func MakeRaw(fd int) (*State, error) {
+	var oldState State
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlReadTermios, uintptr(unsafe.Pointer(&oldState.termios)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+
+	newState := oldState.termios
+	newState.Iflag &^= syscall.ISTRIP | syscall.INLCR | syscall.ICRNL | syscall.IGNCR | syscall.IXON | syscall.IXOFF
+	newState.Lflag &^= syscall.ECHO | syscall.ICANON | syscall.ISIG
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlWriteTermios, uintptr(unsafe.Pointer(&newState)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+
+	return &oldState, nil
+}
+
+// GetState returns the current state of a terminal which may be useful to
+// restore the terminal after a signal.
+func GetState(fd int) (*State, error) {
+	var oldState State
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlReadTermios, uintptr(unsafe.Pointer(&oldState.termios)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+
+	return &oldState, nil
+}
+
+// Restore restores the terminal connected to the given file descriptor to a
+// previous state.
+func Restore(fd int, state *State) error {
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlWriteTermios, uintptr(unsafe.Pointer(&state.termios)), 0, 0, 0)
+	return err
+}
+
+// GetSize returns the dimensions of the given terminal.
+func GetSize(fd int) (width, height int, err error) {
+	var dimensions [4]uint16
+
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(&dimensions)), 0, 0, 0); err != 0 {
+		return -1, -1, err
+	}
+	return int(dimensions[1]), int(dimensions[0]), nil
+}
+
+// ReadPassword reads a line of input from a terminal without local echo.  This
+// is commonly used for inputting passwords and other sensitive data. The slice
+// returned does not include the \n.
+func ReadPassword(fd int) ([]byte, error) {
+	var oldState syscall.Termios
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlReadTermios, uintptr(unsafe.Pointer(&oldState)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+
+	newState := oldState
+	newState.Lflag &^= syscall.ECHO
+	newState.Lflag |= syscall.ICANON | syscall.ISIG
+	newState.Iflag |= syscall.ICRNL
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlWriteTermios, uintptr(unsafe.Pointer(&newState)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+
+	defer func() {
+		syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlWriteTermios, uintptr(unsafe.Pointer(&oldState)), 0, 0, 0)
+	}()
+
+	var buf [16]byte
+	var ret []byte
+	for {
+		n, err := syscall.Read(fd, buf[:])
+		if err != nil {
+			return nil, err
+		}
+		if n == 0 {
+			if len(ret) == 0 {
+				return nil, io.EOF
+			}
+			break
+		}
+		if buf[n-1] == '\n' {
+			n--
+		}
+		ret = append(ret, buf[:n]...)
+		if n < len(buf) {
+			break
+		}
+	}
+
+	return ret, nil
+}

--- a/gregord/vendor/golang.org/x/crypto/ssh/terminal/util_bsd.go
+++ b/gregord/vendor/golang.org/x/crypto/ssh/terminal/util_bsd.go
@@ -1,0 +1,12 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package terminal
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TIOCGETA
+const ioctlWriteTermios = syscall.TIOCSETA

--- a/gregord/vendor/golang.org/x/crypto/ssh/terminal/util_linux.go
+++ b/gregord/vendor/golang.org/x/crypto/ssh/terminal/util_linux.go
@@ -1,0 +1,11 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package terminal
+
+// These constants are declared here, rather than importing
+// them from the syscall package as some syscall packages, even
+// on linux, for example gccgo, do not declare them.
+const ioctlReadTermios = 0x5401  // syscall.TCGETS
+const ioctlWriteTermios = 0x5402 // syscall.TCSETS

--- a/gregord/vendor/golang.org/x/crypto/ssh/terminal/util_windows.go
+++ b/gregord/vendor/golang.org/x/crypto/ssh/terminal/util_windows.go
@@ -1,0 +1,174 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+// Package terminal provides support functions for dealing with terminals, as
+// commonly found on UNIX systems.
+//
+// Putting a terminal into raw mode is the most common requirement:
+//
+// 	oldState, err := terminal.MakeRaw(0)
+// 	if err != nil {
+// 	        panic(err)
+// 	}
+// 	defer terminal.Restore(0, oldState)
+package terminal
+
+import (
+	"io"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	enableLineInput       = 2
+	enableEchoInput       = 4
+	enableProcessedInput  = 1
+	enableWindowInput     = 8
+	enableMouseInput      = 16
+	enableInsertMode      = 32
+	enableQuickEditMode   = 64
+	enableExtendedFlags   = 128
+	enableAutoPosition    = 256
+	enableProcessedOutput = 1
+	enableWrapAtEolOutput = 2
+)
+
+var kernel32 = syscall.NewLazyDLL("kernel32.dll")
+
+var (
+	procGetConsoleMode             = kernel32.NewProc("GetConsoleMode")
+	procSetConsoleMode             = kernel32.NewProc("SetConsoleMode")
+	procGetConsoleScreenBufferInfo = kernel32.NewProc("GetConsoleScreenBufferInfo")
+)
+
+type (
+	short int16
+	word  uint16
+
+	coord struct {
+		x short
+		y short
+	}
+	smallRect struct {
+		left   short
+		top    short
+		right  short
+		bottom short
+	}
+	consoleScreenBufferInfo struct {
+		size              coord
+		cursorPosition    coord
+		attributes        word
+		window            smallRect
+		maximumWindowSize coord
+	}
+)
+
+type State struct {
+	mode uint32
+}
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal(fd int) bool {
+	var st uint32
+	r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, uintptr(fd), uintptr(unsafe.Pointer(&st)), 0)
+	return r != 0 && e == 0
+}
+
+// MakeRaw put the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func MakeRaw(fd int) (*State, error) {
+	var st uint32
+	_, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, uintptr(fd), uintptr(unsafe.Pointer(&st)), 0)
+	if e != 0 {
+		return nil, error(e)
+	}
+	st &^= (enableEchoInput | enableProcessedInput | enableLineInput | enableProcessedOutput)
+	_, _, e = syscall.Syscall(procSetConsoleMode.Addr(), 2, uintptr(fd), uintptr(st), 0)
+	if e != 0 {
+		return nil, error(e)
+	}
+	return &State{st}, nil
+}
+
+// GetState returns the current state of a terminal which may be useful to
+// restore the terminal after a signal.
+func GetState(fd int) (*State, error) {
+	var st uint32
+	_, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, uintptr(fd), uintptr(unsafe.Pointer(&st)), 0)
+	if e != 0 {
+		return nil, error(e)
+	}
+	return &State{st}, nil
+}
+
+// Restore restores the terminal connected to the given file descriptor to a
+// previous state.
+func Restore(fd int, state *State) error {
+	_, _, err := syscall.Syscall(procSetConsoleMode.Addr(), 2, uintptr(fd), uintptr(state.mode), 0)
+	return err
+}
+
+// GetSize returns the dimensions of the given terminal.
+func GetSize(fd int) (width, height int, err error) {
+	var info consoleScreenBufferInfo
+	_, _, e := syscall.Syscall(procGetConsoleScreenBufferInfo.Addr(), 2, uintptr(fd), uintptr(unsafe.Pointer(&info)), 0)
+	if e != 0 {
+		return 0, 0, error(e)
+	}
+	return int(info.size.x), int(info.size.y), nil
+}
+
+// ReadPassword reads a line of input from a terminal without local echo.  This
+// is commonly used for inputting passwords and other sensitive data. The slice
+// returned does not include the \n.
+func ReadPassword(fd int) ([]byte, error) {
+	var st uint32
+	_, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, uintptr(fd), uintptr(unsafe.Pointer(&st)), 0)
+	if e != 0 {
+		return nil, error(e)
+	}
+	old := st
+
+	st &^= (enableEchoInput)
+	st |= (enableProcessedInput | enableLineInput | enableProcessedOutput)
+	_, _, e = syscall.Syscall(procSetConsoleMode.Addr(), 2, uintptr(fd), uintptr(st), 0)
+	if e != 0 {
+		return nil, error(e)
+	}
+
+	defer func() {
+		syscall.Syscall(procSetConsoleMode.Addr(), 2, uintptr(fd), uintptr(old), 0)
+	}()
+
+	var buf [16]byte
+	var ret []byte
+	for {
+		n, err := syscall.Read(syscall.Handle(fd), buf[:])
+		if err != nil {
+			return nil, err
+		}
+		if n == 0 {
+			if len(ret) == 0 {
+				return nil, io.EOF
+			}
+			break
+		}
+		if buf[n-1] == '\n' {
+			n--
+		}
+		if n > 0 && buf[n-1] == '\r' {
+			n--
+		}
+		ret = append(ret, buf[:n]...)
+		if n < len(buf) {
+			break
+		}
+	}
+
+	return ret, nil
+}

--- a/gregord/vendor/vendor.json
+++ b/gregord/vendor/vendor.json
@@ -55,6 +55,11 @@
 			"revisionTime": "2016-04-21T10:04:43-07:00"
 		},
 		{
+			"path": "github.com/keybase/go-logging",
+			"revision": "f3c7c3c1605e29ebcce430bb1e0d048faf4081ce",
+			"revisionTime": "2016-03-23T15:35:38-07:00"
+		},
+		{
 			"path": "github.com/keybase/gregor",
 			"revision": "981e40adf9373075abd789255a21b2e56ec57ffb",
 			"revisionTime": "2016-04-21T10:43:38-07:00"
@@ -159,6 +164,11 @@
 			"path": "github.com/vaughan0/go-ini",
 			"revision": "a98ad7ee00ec53921f08832bc06ecf7fd600e6a1",
 			"revisionTime": "2013-09-23T16:52:12+02:00"
+		},
+		{
+			"path": "golang.org/x/crypto/ssh/terminal",
+			"revision": "7b85b097bf7527677d54d3220065e966a0e3b613",
+			"revisionTime": "2015-11-30T17:07:01-05:00"
 		},
 		{
 			"checksumSHA1": "pancewZW3HwGvpDwfH5Imrbadc4=",

--- a/gregord/vendor/vendor.json
+++ b/gregord/vendor/vendor.json
@@ -66,8 +66,8 @@
 		},
 		{
 			"path": "github.com/keybase/gregor/rpc",
-			"revision": "981e40adf9373075abd789255a21b2e56ec57ffb",
-			"revisionTime": "2016-04-21T10:43:38-07:00"
+			"revision": "b08edbb2cb468f1a4cc43d473f868d870e42e580",
+			"revisionTime": "2016-04-22T16:58:34-04:00"
 		},
 		{
 			"path": "github.com/keybase/gregor/storage",

--- a/rpc/connection.go
+++ b/rpc/connection.go
@@ -71,7 +71,6 @@ type connection struct {
 }
 
 func newConnection(c net.Conn, parent *Server) (*connection, error) {
-	// TODO: logging and error wrapping mechanisms.
 	xprt := rpc.NewTransport(c, rpc.NewSimpleLogFactory(parent.log, nil), keybase1.WrapError)
 
 	conn := &connection{
@@ -169,7 +168,6 @@ func (c *connection) Ping(ctx context.Context) (string, error) {
 }
 
 func (c *connection) startRPCServer() error {
-	// TODO: error wrapping mechanism
 	c.server = rpc.NewServer(c.xprt, keybase1.WrapError)
 
 	prots := []rpc.Protocol{

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -7,11 +7,10 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
+	rpc "github.com/keybase/go-framed-msgpack-rpc"
 	"github.com/keybase/gregor"
 	"github.com/keybase/gregor/protocol/gregor1"
 	"golang.org/x/net/context"
-
-	rpc "github.com/keybase/go-framed-msgpack-rpc"
 )
 
 // ErrBadCast occurs when there is a problem casting a type from

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -78,7 +78,7 @@ var mockAuthenticator gregor1.AuthInterface = mockAuth{
 
 func startTestServer(incoming gregor1.IncomingInterface) (*Server, net.Listener, *test.Events) {
 	ev := test.NewEvents()
-	s := NewServer()
+	s := NewServer(rpc.SimpleLogOutput{})
 	s.events = ev
 	s.useDeadlocker = true
 	s.SetAuthenticator(mockAuthenticator)

--- a/storage/client.go
+++ b/storage/client.go
@@ -3,12 +3,13 @@ package storage
 import (
 	"bytes"
 	"errors"
-	"log"
 	"time"
 
 	"github.com/keybase/gregor"
 	"github.com/keybase/gregor/protocol/gregor1"
 	"golang.org/x/net/context"
+
+	rpc "github.com/keybase/go-framed-msgpack-rpc"
 )
 
 type LocalStorageEngine interface {
@@ -22,15 +23,17 @@ type Client struct {
 	sm       gregor.StateMachine
 	storage  LocalStorageEngine
 	incoming gregor1.IncomingInterface
+	log      rpc.LogOutput
 }
 
-func NewClient(user gregor.UID, device gregor.DeviceID, sm gregor.StateMachine, storage LocalStorageEngine, incoming gregor1.IncomingInterface) *Client {
+func NewClient(user gregor.UID, device gregor.DeviceID, sm gregor.StateMachine, storage LocalStorageEngine, incoming gregor1.IncomingInterface, log rpc.LogOutput) *Client {
 	return &Client{
 		user:     user,
 		device:   device,
 		sm:       sm,
 		storage:  storage,
 		incoming: incoming,
+		log:      log,
 	}
 }
 
@@ -113,7 +116,7 @@ func (c *Client) syncFromTime(t *time.Time) error {
 func (c *Client) Sync() error {
 	if err := c.syncFromTime(c.sm.LatestCTime(c.user, c.device)); err != nil {
 		if _, ok := err.(errHashMismatch); ok {
-			log.Printf("Sync failure: %v\nReseting StateMachine and retrying", err)
+			c.log.Info("Sync failure: %v\nReseting StateMachine and retrying", err)
 			c.sm.Clear()
 			err = c.syncFromTime(nil)
 		}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/keybase/gregor/protocol/gregor1"
 	"github.com/keybase/gregor/test"
 	"github.com/syndtr/goleveldb/leveldb"
+
+	rpc "github.com/keybase/go-framed-msgpack-rpc"
 )
 
 type clientServerSM struct {
@@ -90,7 +92,7 @@ func TestLevelDBClient(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := NewClient(user, device, sm, &LevelDBStorageEngine{db}, gregor1.NewLocalIncoming(sm.server))
+	c := NewClient(user, device, sm, &LevelDBStorageEngine{db}, gregor1.NewLocalIncoming(sm.server), rpc.SimpleLogOutput{})
 
 	if err := c.Save(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Make shared parts of the code take logger objects as arguments. The main
function instantiates a go-logging backend, with optional support for
syslog. The client will eventually pass in a client logging
implementation of its own.

This PR will probably replace https://github.com/keybase/gregor/pull/48, which didn't take a contextified approach to the shared code that client will be using. Depending on `rpc.LogOutput` was the easiest thing here, but we can also have gregor reach further and depend on `client/go/logger` if we want. (We might have to make a much larger wrapper object in that case, because the client interface has a couple dozen methods.)

I also switched out `logrus` for `go-logging`, because once we're passing contextified objects around there's essentially no difference between them at all, and the latter gives us a little more control over the multiple backends.

r? @jacobhaven @maxtaco 