### PR TITLE
improve the filenames in gregor log output

### DIFF
--- a/daemons/log.go
+++ b/daemons/log.go
@@ -74,5 +74,6 @@ func NewLogger() rpc.LogOutput {
 
 	logger := logging.MustGetLogger("gregord")
 	logger.SetBackend(logging.MultiLogger(backends...))
+	logger.ExtraCalldepth = 1
 	return &GoLoggingWrapperForRPC{logger}
 }


### PR DESCRIPTION
Previously we were wrapping the logger object but not setting
ExtraCalldepth, so all our log lines uselessly referred to the log.go
wrappers.

r? @jacobhaven @maxtaco 