### PR TITLE
avoid a value-method-receiver gotcha in SetCTime

### DIFF
--- a/bin/vendor/github.com/keybase/gregor/protocol/gregor1/common.go
+++ b/bin/vendor/github.com/keybase/gregor/protocol/gregor1/common.go
@@ -26,13 +26,13 @@ type InBandMessage struct {
 }
 
 type StateUpdateMessage struct {
-	Md_        Metadata   `codec:"md" json:"md"`
+	Md_        *Metadata  `codec:"md" json:"md"`
 	Creation_  *Item      `codec:"creation,omitempty" json:"creation,omitempty"`
 	Dismissal_ *Dismissal `codec:"dismissal,omitempty" json:"dismissal,omitempty"`
 }
 
 type StateSyncMessage struct {
-	Md_ Metadata `codec:"md" json:"md"`
+	Md_ *Metadata `codec:"md" json:"md"`
 }
 
 type MsgRange struct {

--- a/bin/vendor/github.com/keybase/gregor/protocol/gregor1/extras.go
+++ b/bin/vendor/github.com/keybase/gregor/protocol/gregor1/extras.go
@@ -61,27 +61,27 @@ func (d Dismissal) MsgIDsToDismiss() []gregor.MsgID {
 	return ret
 }
 
-func (m Metadata) CTime() time.Time     { return FromTime(m.Ctime_) }
-func (m Metadata) SetCTime(t time.Time) { m.Ctime_ = ToTime(t) }
-func (m Metadata) UID() gregor.UID {
+func (m *Metadata) CTime() time.Time     { return FromTime(m.Ctime_) }
+func (m *Metadata) SetCTime(t time.Time) { m.Ctime_ = ToTime(t) }
+func (m *Metadata) UID() gregor.UID {
 	if m.Uid_ == nil {
 		return nil
 	}
 	return m.Uid_
 }
-func (m Metadata) MsgID() gregor.MsgID {
+func (m *Metadata) MsgID() gregor.MsgID {
 	if m.MsgID_ == nil {
 		return nil
 	}
 	return m.MsgID_
 }
-func (m Metadata) DeviceID() gregor.DeviceID {
+func (m *Metadata) DeviceID() gregor.DeviceID {
 	if m.DeviceID_ == nil {
 		return nil
 	}
 	return m.DeviceID_
 }
-func (m Metadata) InBandMsgType() gregor.InBandMsgType { return gregor.InBandMsgType(m.InBandMsgType_) }
+func (m *Metadata) InBandMsgType() gregor.InBandMsgType { return gregor.InBandMsgType(m.InBandMsgType_) }
 
 func (i ItemAndMetadata) Metadata() gregor.Metadata {
 	if i.Md_ == nil {
@@ -121,7 +121,7 @@ func (s StateUpdateMessage) Creation() gregor.Item {
 	if s.Creation_ == nil {
 		return nil
 	}
-	return ItemAndMetadata{Md_: &s.Md_, Item_: s.Creation_}
+	return ItemAndMetadata{Md_: s.Md_, Item_: s.Creation_}
 }
 func (s StateUpdateMessage) Dismissal() gregor.Dismissal {
 	if s.Dismissal_ == nil {
@@ -336,7 +336,7 @@ var _ gregor.System = System("")
 var _ gregor.Body = Body{}
 var _ gregor.Category = Category("")
 var _ gregor.TimeOrOffset = TimeOrOffset{}
-var _ gregor.Metadata = Metadata{}
+var _ gregor.Metadata = &Metadata{}
 var _ gregor.StateSyncMessage = StateSyncMessage{}
 var _ gregor.MsgRange = MsgRange{}
 var _ gregor.Dismissal = Dismissal{}

--- a/bin/vendor/github.com/keybase/gregor/protocol/gregor1/factory.go
+++ b/bin/vendor/github.com/keybase/gregor/protocol/gregor1/factory.go
@@ -63,17 +63,17 @@ func timeToTimeOrOffset(timeIn *time.Time) (too TimeOrOffset) {
 	return
 }
 
-func (o ObjFactory) makeMetadata(uid gregor.UID, msgid gregor.MsgID, devid gregor.DeviceID, ctime time.Time, i gregor.InBandMsgType) (Metadata, error) {
+func (o ObjFactory) makeMetadata(uid gregor.UID, msgid gregor.MsgID, devid gregor.DeviceID, ctime time.Time, i gregor.InBandMsgType) (*Metadata, error) {
 	uid2, e := castUID(uid)
 	if e != nil {
-		return Metadata{}, e
+		return &Metadata{}, e
 	}
 	devid2, e := castDeviceID(devid)
 	if e != nil {
-		return Metadata{}, e
+		return &Metadata{}, e
 	}
 
-	return Metadata{
+	return &Metadata{
 		Uid_:           uid2,
 		MsgID_:         MsgID(msgid.Bytes()),
 		Ctime_:         ToTime(ctime),
@@ -96,7 +96,7 @@ func (o ObjFactory) MakeItem(u gregor.UID, msgid gregor.MsgID, deviceid gregor.D
 		return nil, err
 	}
 	return ItemAndMetadata{
-		Md_:   &md,
+		Md_:   md,
 		Item_: o.makeItem(c, dtime, body),
 	}, nil
 }
@@ -207,7 +207,7 @@ func (o ObjFactory) MakeInBandMessageFromItem(i gregor.Item) (gregor.InBandMessa
 	}
 	return InBandMessage{
 		StateUpdate_: &StateUpdateMessage{
-			Md_:       *ourItem.Md_,
+			Md_:       ourItem.Md_,
 			Creation_: ourItem.Item_,
 		},
 	}, nil

--- a/bin/vendor/vendor.json
+++ b/bin/vendor/vendor.json
@@ -87,8 +87,8 @@
 		},
 		{
 			"path": "github.com/keybase/gregor/protocol/gregor1",
-			"revision": "bb667e0205ac02538af21208a6ad6d76cb146a65",
-			"revisionTime": "2016-04-28T19:16:00-07:00"
+			"revision": "2ac55fbb8ecf95b14d2912fbc6d5386e7faf2281",
+			"revisionTime": "2016-05-02T11:24:19-04:00"
 		},
 		{
 			"path": "github.com/keybase/gregor/rpc",

--- a/protocol/gregor1/common.go
+++ b/protocol/gregor1/common.go
@@ -26,13 +26,13 @@ type InBandMessage struct {
 }
 
 type StateUpdateMessage struct {
-	Md_        Metadata   `codec:"md" json:"md"`
+	Md_        *Metadata  `codec:"md" json:"md"`
 	Creation_  *Item      `codec:"creation,omitempty" json:"creation,omitempty"`
 	Dismissal_ *Dismissal `codec:"dismissal,omitempty" json:"dismissal,omitempty"`
 }
 
 type StateSyncMessage struct {
-	Md_ Metadata `codec:"md" json:"md"`
+	Md_ *Metadata `codec:"md" json:"md"`
 }
 
 type MsgRange struct {

--- a/protocol/gregor1/extras.go
+++ b/protocol/gregor1/extras.go
@@ -61,27 +61,27 @@ func (d Dismissal) MsgIDsToDismiss() []gregor.MsgID {
 	return ret
 }
 
-func (m Metadata) CTime() time.Time     { return FromTime(m.Ctime_) }
-func (m Metadata) SetCTime(t time.Time) { m.Ctime_ = ToTime(t) }
-func (m Metadata) UID() gregor.UID {
+func (m *Metadata) CTime() time.Time     { return FromTime(m.Ctime_) }
+func (m *Metadata) SetCTime(t time.Time) { m.Ctime_ = ToTime(t) }
+func (m *Metadata) UID() gregor.UID {
 	if m.Uid_ == nil {
 		return nil
 	}
 	return m.Uid_
 }
-func (m Metadata) MsgID() gregor.MsgID {
+func (m *Metadata) MsgID() gregor.MsgID {
 	if m.MsgID_ == nil {
 		return nil
 	}
 	return m.MsgID_
 }
-func (m Metadata) DeviceID() gregor.DeviceID {
+func (m *Metadata) DeviceID() gregor.DeviceID {
 	if m.DeviceID_ == nil {
 		return nil
 	}
 	return m.DeviceID_
 }
-func (m Metadata) InBandMsgType() gregor.InBandMsgType { return gregor.InBandMsgType(m.InBandMsgType_) }
+func (m *Metadata) InBandMsgType() gregor.InBandMsgType { return gregor.InBandMsgType(m.InBandMsgType_) }
 
 func (i ItemAndMetadata) Metadata() gregor.Metadata {
 	if i.Md_ == nil {
@@ -121,7 +121,7 @@ func (s StateUpdateMessage) Creation() gregor.Item {
 	if s.Creation_ == nil {
 		return nil
 	}
-	return ItemAndMetadata{Md_: &s.Md_, Item_: s.Creation_}
+	return ItemAndMetadata{Md_: s.Md_, Item_: s.Creation_}
 }
 func (s StateUpdateMessage) Dismissal() gregor.Dismissal {
 	if s.Dismissal_ == nil {
@@ -336,7 +336,7 @@ var _ gregor.System = System("")
 var _ gregor.Body = Body{}
 var _ gregor.Category = Category("")
 var _ gregor.TimeOrOffset = TimeOrOffset{}
-var _ gregor.Metadata = Metadata{}
+var _ gregor.Metadata = &Metadata{}
 var _ gregor.StateSyncMessage = StateSyncMessage{}
 var _ gregor.MsgRange = MsgRange{}
 var _ gregor.Dismissal = Dismissal{}

--- a/protocol/gregor1/factory.go
+++ b/protocol/gregor1/factory.go
@@ -63,17 +63,17 @@ func timeToTimeOrOffset(timeIn *time.Time) (too TimeOrOffset) {
 	return
 }
 
-func (o ObjFactory) makeMetadata(uid gregor.UID, msgid gregor.MsgID, devid gregor.DeviceID, ctime time.Time, i gregor.InBandMsgType) (Metadata, error) {
+func (o ObjFactory) makeMetadata(uid gregor.UID, msgid gregor.MsgID, devid gregor.DeviceID, ctime time.Time, i gregor.InBandMsgType) (*Metadata, error) {
 	uid2, e := castUID(uid)
 	if e != nil {
-		return Metadata{}, e
+		return &Metadata{}, e
 	}
 	devid2, e := castDeviceID(devid)
 	if e != nil {
-		return Metadata{}, e
+		return &Metadata{}, e
 	}
 
-	return Metadata{
+	return &Metadata{
 		Uid_:           uid2,
 		MsgID_:         MsgID(msgid.Bytes()),
 		Ctime_:         ToTime(ctime),
@@ -96,7 +96,7 @@ func (o ObjFactory) MakeItem(u gregor.UID, msgid gregor.MsgID, deviceid gregor.D
 		return nil, err
 	}
 	return ItemAndMetadata{
-		Md_:   &md,
+		Md_:   md,
 		Item_: o.makeItem(c, dtime, body),
 	}, nil
 }
@@ -207,7 +207,7 @@ func (o ObjFactory) MakeInBandMessageFromItem(i gregor.Item) (gregor.InBandMessa
 	}
 	return InBandMessage{
 		StateUpdate_: &StateUpdateMessage{
-			Md_:       *ourItem.Md_,
+			Md_:       ourItem.Md_,
 			Creation_: ourItem.Item_,
 		},
 	}, nil

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -208,7 +208,7 @@ func newUpdateMessage(uid gregor1.UID) gregor1.Message {
 	return gregor1.Message{
 		Ibm_: &gregor1.InBandMessage{
 			StateUpdate_: &gregor1.StateUpdateMessage{
-				Md_: gregor1.Metadata{
+				Md_: &gregor1.Metadata{
 					Uid_: uid,
 				},
 			},


### PR DESCRIPTION
r? @jacobhaven @maxtaco 

I noticed that `protocol/gregor1/extras.go` defines a lot of value receivers, and that made me want to look for cases where the methods there were trying to modify the receiver (because these modifications will happen on copies and get silently dropped). I believe `Metadata.SetCTime` is one of these. This diff makes all of its methods take a pointer instead, and propagates that change out to the other structs that contain it.

Do you guys think this is the right fix, or would it be better to remove `SetCTime` from the `Metadata` interface, and keep the value type?