### PR TITLE
fix an impossible cast

### DIFF
--- a/bin/vendor/github.com/keybase/gregor/protocol/gregor1/extras.go
+++ b/bin/vendor/github.com/keybase/gregor/protocol/gregor1/extras.go
@@ -204,14 +204,14 @@ func (m Message) ToInBandMessage() gregor.InBandMessage {
 	if m.Ibm_ == nil {
 		return nil
 	}
-	return m.Ibm_
+	return *m.Ibm_
 }
 
 func (m Message) ToOutOfBandMessage() gregor.OutOfBandMessage {
 	if m.Oobm_ == nil {
 		return nil
 	}
-	return m.Oobm_
+	return *m.Oobm_
 }
 
 func (r Reminder) Item() gregor.Item     { return r.Item_ }
@@ -311,8 +311,11 @@ func (i *localIncoming) Sync(_ context.Context, arg SyncArg) (res SyncResult, er
 	}
 
 	for _, msg := range msgs {
-		if msg, ok := msg.(*InBandMessage); ok {
-			res.Msgs = append(res.Msgs, *msg)
+		if msg, ok := msg.(InBandMessage); ok {
+			res.Msgs = append(res.Msgs, msg)
+		} else {
+			// TODO: Avoid making this cast entirely.
+			panic("This cast should never fail.")
 		}
 	}
 

--- a/bin/vendor/vendor.json
+++ b/bin/vendor/vendor.json
@@ -87,8 +87,8 @@
 		},
 		{
 			"path": "github.com/keybase/gregor/protocol/gregor1",
-			"revision": "bb667e0205ac02538af21208a6ad6d76cb146a65",
-			"revisionTime": "2016-04-28T19:16:00-07:00"
+			"revision": "7460d6bfb4bd79252aa03ccaf8c2093878c98d07",
+			"revisionTime": "2016-05-02T13:52:31-04:00"
 		},
 		{
 			"path": "github.com/keybase/gregor/rpc",

--- a/protocol/gregor1/extras.go
+++ b/protocol/gregor1/extras.go
@@ -204,14 +204,14 @@ func (m Message) ToInBandMessage() gregor.InBandMessage {
 	if m.Ibm_ == nil {
 		return nil
 	}
-	return m.Ibm_
+	return *m.Ibm_
 }
 
 func (m Message) ToOutOfBandMessage() gregor.OutOfBandMessage {
 	if m.Oobm_ == nil {
 		return nil
 	}
-	return m.Oobm_
+	return *m.Oobm_
 }
 
 func (r Reminder) Item() gregor.Item     { return r.Item_ }
@@ -330,8 +330,11 @@ func (i *localIncoming) Sync(_ context.Context, arg SyncArg) (res SyncResult, er
 	}
 
 	for _, msg := range msgs {
-		if msg, ok := msg.(*InBandMessage); ok {
-			res.Msgs = append(res.Msgs, *msg)
+		if msg, ok := msg.(InBandMessage); ok {
+			res.Msgs = append(res.Msgs, msg)
+		} else {
+			// TODO: Avoid making this cast entirely.
+			panic("This cast should never fail.")
 		}
 	}
 


### PR DESCRIPTION
When we implement an interface with by-value methods, the pointer type
implicitly also implements the interface. That means the compiler won't
yell at you if you try to cast back into a pointer, even though the cast
will in practice always fail, because we use values everywhere.

r? @maxtaco @jacobhaven (@patrickxb would you like to be cc'd on gregor PRs too?)