### PR TITLE
add a String() method to MsgID

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -21,6 +21,7 @@ type UID interface {
 
 type MsgID interface {
 	Bytes() []byte
+	String() string
 }
 
 type DeviceID interface {

--- a/interface.go
+++ b/interface.go
@@ -17,6 +17,7 @@ const (
 
 type UID interface {
 	Bytes() []byte
+	String() string
 }
 
 type MsgID interface {
@@ -26,6 +27,7 @@ type MsgID interface {
 
 type DeviceID interface {
 	Bytes() []byte
+	String() string
 }
 
 type System interface {

--- a/protocol/gregor1/extras.go
+++ b/protocol/gregor1/extras.go
@@ -12,7 +12,9 @@ import (
 )
 
 func (u UID) Bytes() []byte            { return []byte(u) }
+func (u UID) String() string           { return hex.EncodeToString(u) }
 func (d DeviceID) Bytes() []byte       { return []byte(d) }
+func (d DeviceID) String() string      { return hex.EncodeToString(d) }
 func (m MsgID) Bytes() []byte          { return []byte(m) }
 func (m MsgID) String() string         { return hex.EncodeToString(m) }
 func (s System) String() string        { return string(s) }

--- a/protocol/gregor1/extras.go
+++ b/protocol/gregor1/extras.go
@@ -2,6 +2,7 @@ package gregor1
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"time"
@@ -13,6 +14,7 @@ import (
 func (u UID) Bytes() []byte            { return []byte(u) }
 func (d DeviceID) Bytes() []byte       { return []byte(d) }
 func (m MsgID) Bytes() []byte          { return []byte(m) }
+func (m MsgID) String() string         { return hex.EncodeToString(m) }
 func (s System) String() string        { return string(s) }
 func (c Category) String() string      { return string(c) }
 func (b Body) Bytes() []byte           { return []byte(b) }


### PR DESCRIPTION
@maxtaco @patrickxb @jacobhaven let me know what you guys think about adding these string methods as we need them? Alternatives include implementing some global interface for anything that has `Bytes()`, or just using `EncodeToString` manually everywhere.