### PR TITLE
rename DB tables and session server

### DIFF
--- a/bin/gregord/flag_test.go
+++ b/bin/gregord/flag_test.go
@@ -29,21 +29,21 @@ func TestUsage(t *testing.T) {
 	testBadUsage(t, []string{"gregor", "-bind-address", "localhost:aabb"}, ebu, "bad port (\"aabb\") in bind-address")
 	testBadUsage(t, []string{"gregor", "-bind-address", "localhost:65537"}, ebu, "bad port (\"65537\") in bind-address")
 	testBadUsage(t, []string{"gregor", "-bind-address", "localhost:-20"}, ebu, "bad port (\"-20\") in bind-address")
-	testBadUsage(t, []string{"gregor", "-bind-address", ":4000", "-mysql-dsn", "gregor:@/gregor_test"}, ebu, "Error parsing session server URI")
-	testBadUsage(t, []string{"gregor", "-bind-address", ":4000", "-mysql-dsn", "gregor:@/gregor_test", "-session-server", "XXXXX://localhost:30000"}, ebu, "invalid framed msgpack rpc scheme")
-	testBadUsage(t, []string{"gregor", "-bind-address", ":4000", "-mysql-dsn", "gregor:@/gregor_test", "-session-server", "fmprpc://localhost:30000", "-tls-key", "hi"},
+	testBadUsage(t, []string{"gregor", "-bind-address", ":4000", "-mysql-dsn", "gregor:@/gregor_test"}, ebu, "Error parsing auth server URI")
+	testBadUsage(t, []string{"gregor", "-bind-address", ":4000", "-mysql-dsn", "gregor:@/gregor_test", "-auth-server", "XXXXX://localhost:30000"}, ebu, "invalid framed msgpack rpc scheme")
+	testBadUsage(t, []string{"gregor", "-bind-address", ":4000", "-mysql-dsn", "gregor:@/gregor_test", "-auth-server", "fmprpc://localhost:30000", "-tls-key", "hi"},
 		ebu, "you must provide a TLS Key and a TLS cert, or neither")
-	testBadUsage(t, []string{"gregor", "-bind-address", ":4000", "-mysql-dsn", "gregor:@/gregor_test", "-session-server", "fmprpc://localhost:30000", "-tls-cert", "hi"},
+	testBadUsage(t, []string{"gregor", "-bind-address", ":4000", "-mysql-dsn", "gregor:@/gregor_test", "-auth-server", "fmprpc://localhost:30000", "-tls-cert", "hi"},
 		ebu, "you must provide a TLS Key and a TLS cert, or neither")
-	testBadUsage(t, []string{"gregor", "-bind-address", ":4000", "-session-server", "fmprpc://localhost:30000", "-tls-key", "hi",
+	testBadUsage(t, []string{"gregor", "-bind-address", ":4000", "-auth-server", "fmprpc://localhost:30000", "-tls-key", "hi",
 		"-tls-cert", "bye", "-aws-region", "foo", "-mysql-dsn", "gregor:@/gregor_test"}, ebu, "you must provide an AWS Region and a Config bucket")
-	testBadUsage(t, []string{"gregor", "-bind-address", ":4000", "-session-server", "fmprpc://localhost:30000", "-tls-key", "hi",
+	testBadUsage(t, []string{"gregor", "-bind-address", ":4000", "-auth-server", "fmprpc://localhost:30000", "-tls-key", "hi",
 		"-tls-cert", "bye", "-s3-config-bucket", "foo", "-mysql-dsn", "gregor:@/gregor_test"}, ebu, "you must provide an AWS Region and a Config bucket")
-	testBadUsage(t, []string{"gregor", "-bind-address", ":4000", "-session-server", "fmprpc://localhost:30000", "-tls-key", "hi",
+	testBadUsage(t, []string{"gregor", "-bind-address", ":4000", "-auth-server", "fmprpc://localhost:30000", "-tls-key", "hi",
 		"-tls-cert", "file:///does/not/exist", "-mysql-dsn", "gregor:@/gregor_test"}, bin.ErrBadConfig(""), "no such file or directory")
 
-	testGoodUsage(t, []string{"gregor", "-session-server", "fmprpc://localhost:30000", "-bind-address", ":4000", "-mysql-dsn", "gregor:@/gregor_test"})
-	testGoodUsage(t, []string{"gregor", "-session-server", "fmprpc://localhost:30000", "-bind-address", "127.0.0.1:4000", "-mysql-dsn", "gregor:@/gregor_test"})
-	testGoodUsage(t, []string{"gregor", "-session-server", "fmprpc://localhost:30000", "-bind-address", "0.0.0.0:4000", "-mysql-dsn", "gregor:@/gregor_test"})
-	testGoodUsage(t, []string{"gregor", "-session-server", "fmprpc://localhost:30000", "-bind-address", "localhost:4000", "-mysql-dsn", os.Getenv("MYSQL_DSN")})
+	testGoodUsage(t, []string{"gregor", "-auth-server", "fmprpc://localhost:30000", "-bind-address", ":4000", "-mysql-dsn", "gregor:@/gregor_test"})
+	testGoodUsage(t, []string{"gregor", "-auth-server", "fmprpc://localhost:30000", "-bind-address", "127.0.0.1:4000", "-mysql-dsn", "gregor:@/gregor_test"})
+	testGoodUsage(t, []string{"gregor", "-auth-server", "fmprpc://localhost:30000", "-bind-address", "0.0.0.0:4000", "-mysql-dsn", "gregor:@/gregor_test"})
+	testGoodUsage(t, []string{"gregor", "-auth-server", "fmprpc://localhost:30000", "-bind-address", "localhost:4000", "-mysql-dsn", os.Getenv("MYSQL_DSN")})
 }

--- a/bin/gregord/main.go
+++ b/bin/gregord/main.go
@@ -41,7 +41,7 @@ func main() {
 	if opts.MockAuth {
 		srv.SetAuthenticator(newMockAuth())
 	} else {
-		sc := server.NewSessionCacherFromURI(opts.SessionServer, clockwork.NewRealClock(),
+		sc := server.NewSessionCacherFromURI(opts.AuthServer, clockwork.NewRealClock(),
 			10*time.Minute, log, rpcopts)
 		defer sc.Close()
 

--- a/bin/gregord/server_test.go
+++ b/bin/gregord/server_test.go
@@ -178,7 +178,7 @@ func TestRunTLS(t *testing.T) {
 	opts, err := ParseOptions([]string{
 		"gregor",
 		"--bind-address", bindAddress,
-		"--session-server", "fmprpc+tls://localhost:30000",
+		"--auth-server", "fmprpc+tls://localhost:30000",
 		"--tls-key", ("file://" + key),
 		"--tls-cert", ("file://" + crt),
 		"--mysql-dsn", "gregor:@/gregor_test",
@@ -224,7 +224,7 @@ func TestRunTCP(t *testing.T) {
 	opts, err := ParseOptions([]string{
 		"gregor",
 		"--bind-address", bindAddress,
-		"--session-server", "fmprpc://localhost:30000",
+		"--auth-server", "fmprpc://localhost:30000",
 		"--mysql-dsn", "gregor:@/gregor_test",
 	})
 	require.Nil(t, err, "no error")

--- a/storage/sql_schema.go
+++ b/storage/sql_schema.go
@@ -2,13 +2,13 @@ package storage
 
 var schema = []string{
 
-	`DROP TABLE IF EXISTS dismissals_by_time`,
-	`DROP TABLE IF EXISTS dismissals_by_id`,
-	`DROP TABLE IF EXISTS reminders`,
-	`DROP TABLE IF EXISTS items`,
-	`DROP TABLE IF EXISTS messages`,
+	`DROP TABLE IF EXISTS gregor_dismissals_by_time`,
+	`DROP TABLE IF EXISTS gregor_dismissals_by_id`,
+	`DROP TABLE IF EXISTS gregor_reminders`,
+	`DROP TABLE IF EXISTS gregor_items`,
+	`DROP TABLE IF EXISTS gregor_messages`,
 
-	`CREATE TABLE messages (
+	`CREATE TABLE gregor_messages (
 		uid   CHAR(32) NOT NULL,
 		msgid CHAR(32) NOT NULL,
 		ctime DATETIME(6) NOT NULL,
@@ -17,43 +17,43 @@ var schema = []string{
 		PRIMARY KEY(uid, msgid)
 	)`,
 
-	`CREATE TABLE items (
+	`CREATE TABLE gregor_items (
 		uid   CHAR(32) NOT NULL,
 		msgid CHAR(32) NOT NULL,
 		category VARCHAR(128) NOT NULL,
 		dtime DATETIME(6),
 		body BLOB,
-		FOREIGN KEY(uid, msgid) REFERENCES messages (uid, msgid) ON DELETE CASCADE,
+		FOREIGN KEY(uid, msgid) REFERENCES gregor_messages (uid, msgid) ON DELETE CASCADE,
 		PRIMARY KEY(uid, msgid)
 	)`,
 
-	`CREATE INDEX user_order ON items (uid, category)`,
+	`CREATE INDEX gregor_user_order ON gregor_items (uid, category)`,
 
-	`CREATE INDEX cleanup_order ON items (uid, dtime)`,
+	`CREATE INDEX gregor_cleanup_order ON gregor_items (uid, dtime)`,
 
-	`CREATE TABLE reminders (
+	`CREATE TABLE gregor_reminders (
 		uid   CHAR(32) NOT NULL,
 		msgid CHAR(32) NOT NULL,
 		rtime DATETIME(6) NOT NULL,
-		FOREIGN KEY(uid, msgid) REFERENCES messages (uid, msgid) ON DELETE CASCADE,
+		FOREIGN KEY(uid, msgid) REFERENCES gregor_messages (uid, msgid) ON DELETE CASCADE,
 		PRIMARY KEY(uid, msgid, rtime)
 	)`,
 
-	`CREATE TABLE dismissals_by_id (
+	`CREATE TABLE gregor_dismissals_by_id (
 		uid   CHAR(32) NOT NULL,
 		msgid CHAR(32) NOT NULL,
 		dmsgid CHAR(32) NOT NULL, -- "the message IDs to dismiss",
-		FOREIGN KEY(uid, msgid) REFERENCES messages (uid, msgid) ON DELETE CASCADE,
-		FOREIGN KEY(uid, dmsgid) REFERENCES messages (uid, msgid) ON DELETE CASCADE,
+		FOREIGN KEY(uid, msgid) REFERENCES gregor_messages (uid, msgid) ON DELETE CASCADE,
+		FOREIGN KEY(uid, dmsgid) REFERENCES gregor_messages (uid, msgid) ON DELETE CASCADE,
 		PRIMARY KEY(uid, msgid, dmsgid)
 	)`,
 
-	`CREATE TABLE dismissals_by_time (
+	`CREATE TABLE gregor_dismissals_by_time (
 		uid   CHAR(32) NOT NULL,
 		msgid CHAR(32) NOT NULL,
 		category VARCHAR(128) NOT NULL,
 		dtime DATETIME(6) NOT NULL, -- "throw out matching events before dtime",
-		FOREIGN KEY(uid, msgid) REFERENCES messages (uid, msgid) ON DELETE CASCADE,
+		FOREIGN KEY(uid, msgid) REFERENCES gregor_messages (uid, msgid) ON DELETE CASCADE,
 		PRIMARY KEY(uid, msgid, category, dtime)
 	)`,
 }


### PR DESCRIPTION
- prefix all DB tables with `gregor_` so that we can, optionally, store this data in an existing database.
- rename session server to auth server