### PR TITLE
Make errors human readable

### DIFF
--- a/bin/gregord/main.go
+++ b/bin/gregord/main.go
@@ -21,7 +21,7 @@ func main() {
 
 	opts, err := ParseOptions(os.Args)
 	if err != nil {
-		log.Error("%#v", err)
+		log.Error("%s", err)
 		os.Exit(1)
 	}
 
@@ -53,7 +53,7 @@ func main() {
 	db, err := sql.Open("mysql", opts.MysqlDSN)
 
 	if err != nil {
-		log.Error("%#v", err)
+		log.Error("%s", err)
 		os.Exit(3)
 	}
 	defer func() {
@@ -71,14 +71,14 @@ func main() {
 	go srv.Serve()
 
 	log.Debug("Calling mainServer.listenAndServe()")
-	log.Error("%#v", newMainServer(opts, srv).listenAndServe())
+	log.Error("%s", newMainServer(opts, srv).listenAndServe())
 	os.Exit(4)
 }
 
 func setupPubSub(opts *Options, log *bin.StandardLogger) *srvup.Status {
 	mstore, err := srvup.NewStorageMysql(opts.MysqlDSN, log)
 	if err != nil {
-		log.Error("%#v", err)
+		log.Error("%s", err)
 		os.Exit(3)
 	}
 	statusGroup := srvup.New("gregord", opts.HeartbeatInterval, opts.AliveThreshold, mstore)
@@ -86,7 +86,7 @@ func setupPubSub(opts *Options, log *bin.StandardLogger) *srvup.Status {
 	alive, err := statusGroup.Alive()
 	if err != nil {
 		// bad enough to quit:
-		log.Error("%#v", err)
+		log.Error("%s", err)
 		os.Exit(3)
 	}
 

--- a/bin/rsenderd/main.go
+++ b/bin/rsenderd/main.go
@@ -15,20 +15,20 @@ func main() {
 
 	opts, err := ParseOptions(os.Args)
 	if err != nil {
-		log.Error("%#v", err)
+		log.Error("%s", err)
 		os.Exit(1)
 	}
 
 	db, err := sql.Open("mysql", opts.MysqlDSN)
 	if err != nil {
-		log.Error("%#v", err)
+		log.Error("%s", err)
 		os.Exit(2)
 	}
 
 	r := newRSender(db, opts.RemindServer, log)
 	for _ = range time.Tick(opts.RemindDuration) {
 		if err := r.sendReminders(); err != nil {
-			log.Error("%#v", err)
+			log.Error("%s", err)
 		}
 	}
 }


### PR DESCRIPTION
before:
 ERRO 12:57:35.218 main.go:74 &net.OpError{Op:"listen", Net:"tcp", Source:net.Addr(nil), Addr:(*net.TCPAddr)(0xc820016240), Err:(*os.SyscallError)(0xc82000e280)}

after:
 ERRO 13:00:16.334 main.go:74 listen tcp 127.0.0.1:9911: bind: address already in use