### PR TITLE
state machine generates a ctime

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -125,7 +125,7 @@ type MessageConsumer interface {
 	// perform state mutations, or might be "out-of-band" that just use the
 	// Gregor broadcast mechanism to make sure that all clients get the
 	// notification.
-	ConsumeMessage(m Message) error
+	ConsumeMessage(m Message) (time.Time, error)
 }
 
 // StateMachine is the central interface of the Gregor system. Various parts of the

--- a/protocol/gregor1/extras.go
+++ b/protocol/gregor1/extras.go
@@ -231,6 +231,12 @@ func (m Message) ToOutOfBandMessage() gregor.OutOfBandMessage {
 	return *m.Oobm_
 }
 
+func (m *Message) SetCTime(ctime time.Time) {
+	if m.Ibm_ != nil && m.Ibm_.StateUpdate_ != nil {
+		m.Ibm_.StateUpdate_.Md_.Ctime_ = ToTime(ctime)
+	}
+}
+
 func (r Reminder) Item() gregor.Item     { return r.Item_ }
 func (r Reminder) RemindTime() time.Time { return FromTime(r.RemindTime_) }
 

--- a/rpc/client/client.go
+++ b/rpc/client/client.go
@@ -133,7 +133,7 @@ func (c *Client) Sync(cli gregor1.IncomingInterface) error {
 	return nil
 }
 
-func (c *Client) ConsumeMessage(m gregor1.Message) error {
+func (c *Client) StateMachineConsumeMessage(m gregor1.Message) error {
 	if _, err := c.sm.ConsumeMessage(m); err != nil {
 		return err
 	}
@@ -149,10 +149,10 @@ func (c *Client) ConsumeMessage(m gregor1.Message) error {
 	return nil
 }
 
-func (c *Client) LatestCTime() *time.Time {
+func (c *Client) StateMachineLatestCTime() *time.Time {
 	return c.sm.LatestCTime(c.user, c.device)
 }
 
-func (c *Client) InBandMessagesSince(t time.Time) ([]gregor.InBandMessage, error) {
+func (c *Client) StateMachineInBandMessagesSince(t time.Time) ([]gregor.InBandMessage, error) {
 	return c.sm.InBandMessagesSince(c.user, c.device, t)
 }

--- a/rpc/client/client.go
+++ b/rpc/client/client.go
@@ -93,11 +93,13 @@ func (c *Client) syncFromTime(cli gregor1.IncomingInterface, t *time.Time) error
 	}
 
 	// Grab the events from gregord
+	c.log.Debug("syncFromTime from: %s", gregor1.FromTime(arg.Ctime))
 	res, err := cli.Sync(ctx, arg)
 	if err != nil {
 		return err
 	}
 
+	c.log.Debug("syncFromTime consuming %d messages", len(res.Msgs))
 	for _, ibm := range res.Msgs {
 		m := gregor1.Message{Ibm_: &ibm}
 		c.sm.ConsumeMessage(m)

--- a/rpc/client/client.go
+++ b/rpc/client/client.go
@@ -132,7 +132,7 @@ func (c *Client) Sync(cli gregor1.IncomingInterface) error {
 }
 
 func (c *Client) ConsumeMessage(m gregor1.Message) error {
-	if err := c.sm.ConsumeMessage(m); err != nil {
+	if _, err := c.sm.ConsumeMessage(m); err != nil {
 		return err
 	}
 

--- a/rpc/client/client_test.go
+++ b/rpc/client/client_test.go
@@ -40,14 +40,15 @@ func (sm *clientServerSM) Clear() error {
 	return sm.client.Clear()
 }
 
-func (sm *clientServerSM) ConsumeMessage(m gregor.Message) error {
+func (sm *clientServerSM) ConsumeMessage(m gregor.Message) (time.Time, error) {
 	if sm.client != nil {
-		if err := sm.client.ConsumeMessage(m); err != nil {
-			return err
+		if ctime, err := sm.client.ConsumeMessage(m); err != nil {
+			return ctime, err
 		}
 	}
 
-	return sm.server.ConsumeMessage(m)
+	ctime, err := sm.server.ConsumeMessage(m)
+	return ctime, err
 }
 
 func (sm *clientServerSM) State(u gregor.UID, d gregor.DeviceID, t gregor.TimeOrOffset) (gregor.State, error) {

--- a/rpc/server/main.go
+++ b/rpc/server/main.go
@@ -327,9 +327,11 @@ func (s *Server) startSync(c context.Context, arg gregor1.SyncArg) (gregor1.Sync
 // and broadcasts it to the other clients. Like startSync, this function is called
 // from connection, and is on a different thread than Serve
 func (s *Server) runConsumeMessageMainSequence(c context.Context, m gregor1.Message) error {
-	if err := s.storageConsumeMessage(m); err != nil {
-		return err
+	res := s.storageConsumeMessage(m)
+	if res.err != nil {
+		return res.err
 	}
+	m.SetCTime(res.ctime)
 	s.broadcastConsumeMessage(c, m)
 
 	return s.publishConsumeMessage(c, m)
@@ -409,9 +411,14 @@ func (s *Server) Serve() error {
 	}
 }
 
+type consumeMessageRet struct {
+	err   error
+	ctime time.Time
+}
+
 type consumeMessageReq struct {
 	m      gregor.Message
-	respCh chan<- error
+	respCh chan<- consumeMessageRet
 }
 
 type syncReq struct {
@@ -422,12 +429,15 @@ type syncReq struct {
 }
 
 // storageConsumeMessage schedules a Consume request on the dispatch handler
-func (s *Server) storageConsumeMessage(m gregor.Message) error {
-	retCh := make(chan error)
+func (s *Server) storageConsumeMessage(m gregor.Message) consumeMessageRet {
+	retCh := make(chan consumeMessageRet)
 	req := consumeMessageReq{m: m, respCh: retCh}
 	err := s.storageDispatch(req)
 	if err != nil {
-		return err
+		return consumeMessageRet{
+			err:   err,
+			ctime: time.Now(),
+		}
 	}
 	return <-retCh
 }
@@ -467,7 +477,8 @@ func (s *Server) storageDispatchHandler() {
 	for req := range s.storageDispatchCh {
 		switch req := req.(type) {
 		case consumeMessageReq:
-			req.respCh <- s.storage.ConsumeMessage(req.m)
+			ctime, err := s.storage.ConsumeMessage(req.m)
+			req.respCh <- consumeMessageRet{ctime: ctime, err: err}
 		case syncReq:
 			res, err := grpc.Sync(req.sm, req.log, req.arg)
 			req.respCh <- syncRet{res: res, err: err}

--- a/rpc/server/main.go
+++ b/rpc/server/main.go
@@ -435,8 +435,7 @@ func (s *Server) storageConsumeMessage(m gregor.Message) consumeMessageRet {
 	err := s.storageDispatch(req)
 	if err != nil {
 		return consumeMessageRet{
-			err:   err,
-			ctime: time.Now(),
+			err: err,
 		}
 	}
 	return <-retCh

--- a/storage/mem_sm.go
+++ b/storage/mem_sm.go
@@ -106,6 +106,11 @@ func (u *user) addItems(items []gregor.Item) {
 
 // logMessage logs a message for this user and potentially associates an item
 func (u *user) logMessage(t time.Time, m gregor.InBandMessage, i *item) {
+	for _, l := range u.log {
+		if bytes.Equal(l.m.Metadata().MsgID().Bytes(), m.Metadata().MsgID().Bytes()) {
+			return
+		}
+	}
 	u.log = append(u.log, loggedMsg{m, t, i})
 }
 

--- a/storage/sql_sm.go
+++ b/storage/sql_sm.go
@@ -252,7 +252,7 @@ func (s *SQLEngine) ConsumeMessage(m gregor.Message) (time.Time, error) {
 	case m.ToInBandMessage() != nil:
 		return s.consumeInBandMessage(m.ToInBandMessage())
 	default:
-		return s.clock.Now(), nil
+		return time.Time{}, nil
 	}
 }
 
@@ -261,14 +261,14 @@ func (s *SQLEngine) consumeInBandMessage(m gregor.InBandMessage) (time.Time, err
 	case m.ToStateUpdateMessage() != nil:
 		return s.consumeStateUpdateMessage(m.ToStateUpdateMessage())
 	default:
-		return s.clock.Now(), nil
+		return time.Time{}, nil
 	}
 }
 
 func (s *SQLEngine) consumeStateUpdateMessage(m gregor.StateUpdateMessage) (ctime time.Time, err error) {
 	tx, err := s.driver.Begin()
 	if err != nil {
-		return s.clock.Now(), err
+		return time.Time{}, err
 	}
 	defer func() {
 		if err != nil {
@@ -280,7 +280,7 @@ func (s *SQLEngine) consumeStateUpdateMessage(m gregor.StateUpdateMessage) (ctim
 
 	md := m.Metadata()
 	if md, err = s.consumeInBandMessageMetadata(tx, md, gregor.InBandMsgTypeUpdate); err != nil {
-		return s.clock.Now(), err
+		return time.Time{}, err
 	}
 
 	ctime = md.CTime()

--- a/storage/sql_sm.go
+++ b/storage/sql_sm.go
@@ -247,28 +247,28 @@ func (s *SQLEngine) consumeInBandMessageMetadata(tx *sql.Tx, md gregor.Metadata,
 	return s.objFactory.MakeMetadata(md.UID(), md.MsgID(), md.DeviceID(), ctime, md.InBandMsgType())
 }
 
-func (s *SQLEngine) ConsumeMessage(m gregor.Message) error {
+func (s *SQLEngine) ConsumeMessage(m gregor.Message) (time.Time, error) {
 	switch {
 	case m.ToInBandMessage() != nil:
 		return s.consumeInBandMessage(m.ToInBandMessage())
 	default:
-		return nil
+		return s.clock.Now(), nil
 	}
 }
 
-func (s *SQLEngine) consumeInBandMessage(m gregor.InBandMessage) error {
+func (s *SQLEngine) consumeInBandMessage(m gregor.InBandMessage) (time.Time, error) {
 	switch {
 	case m.ToStateUpdateMessage() != nil:
 		return s.consumeStateUpdateMessage(m.ToStateUpdateMessage())
 	default:
-		return nil
+		return s.clock.Now(), nil
 	}
 }
 
-func (s *SQLEngine) consumeStateUpdateMessage(m gregor.StateUpdateMessage) (err error) {
+func (s *SQLEngine) consumeStateUpdateMessage(m gregor.StateUpdateMessage) (ctime time.Time, err error) {
 	tx, err := s.driver.Begin()
 	if err != nil {
-		return err
+		return s.clock.Now(), err
 	}
 	defer func() {
 		if err != nil {
@@ -280,23 +280,25 @@ func (s *SQLEngine) consumeStateUpdateMessage(m gregor.StateUpdateMessage) (err 
 
 	md := m.Metadata()
 	if md, err = s.consumeInBandMessageMetadata(tx, md, gregor.InBandMsgTypeUpdate); err != nil {
-		return err
+		return s.clock.Now(), err
 	}
+
+	ctime = md.CTime()
 	if m.Creation() != nil {
 		if err = s.consumeCreation(tx, m.Creation()); err != nil {
-			return err
+			return ctime, err
 		}
 	}
 	if m.Dismissal() != nil {
 		if err = s.consumeMsgIDsToDismiss(tx, md.UID(), md.MsgID(), m.Dismissal().MsgIDsToDismiss(), md.CTime()); err != nil {
-			return err
+			return ctime, err
 		}
 		if err = s.consumeRangesToDismiss(tx, md.UID(), md.MsgID(), m.Dismissal().RangesToDismiss(), md.CTime()); err != nil {
-			return err
+			return ctime, err
 		}
 	}
 
-	return nil
+	return ctime, nil
 }
 
 func (s *SQLEngine) rowToItem(u gregor.UID, rows *sql.Rows) (gregor.Item, error) {

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -134,7 +134,7 @@ func newDismissalByCategory(of gregor.ObjFactory, u gregor.UID, m gregor.MsgID, 
 }
 
 func consumeMessage(t *testing.T, which string, sm gregor.StateMachine, m gregor.Message) {
-	err := sm.ConsumeMessage(m)
+	_, err := sm.ConsumeMessage(m)
 	if err != nil {
 		t.Fatalf("In inserting msg %s: %v", which, err)
 	}


### PR DESCRIPTION
@maxtaco @patrickxb @jacobhaven this change adds another return value to `ConsumeMessage` (the ctime) that will come along with `BroadcastMessage` so gregord and the client don't have two different ctime's for the same message.