### PR TITLE
log message with the time of the item

### DIFF
--- a/rpc/client/client.go
+++ b/rpc/client/client.go
@@ -156,3 +156,7 @@ func (c *Client) StateMachineLatestCTime() *time.Time {
 func (c *Client) StateMachineInBandMessagesSince(t time.Time) ([]gregor.InBandMessage, error) {
 	return c.sm.InBandMessagesSince(c.user, c.device, t)
 }
+
+func (c *Client) StateMachineState(t gregor.TimeOrOffset) (gregor.State, error) {
+	return c.sm.State(c.user, c.device, t)
+}

--- a/storage/mem_sm.go
+++ b/storage/mem_sm.go
@@ -252,12 +252,14 @@ func (m *MemEngine) consumeInBandMessage(uid gregor.UID, msg gregor.InBandMessag
 		i, err = m.consumeStateUpdateMessage(user, now, msg.ToStateUpdateMessage())
 	default:
 	}
-	user.logMessage(now, msg, i)
 
 	retTime := now
 	if i != nil {
 		retTime = i.ctime
 	}
+
+	user.logMessage(retTime, msg, i)
+
 	return retTime, err
 }
 


### PR DESCRIPTION
@maxtaco key move here is having `logMessage` use the ctime from the event if it gets sent in, this is useful for testing.