### PR TITLE
use IDs instead of hostnames CORE-3105

### DIFF
--- a/bin/gregord/main.go
+++ b/bin/gregord/main.go
@@ -93,7 +93,7 @@ func setupPubSub(opts *Options, log *bin.StandardLogger) (*srvup.Status, error) 
 	if err != nil {
 		return nil, err
 	}
-	statusGroup := srvup.New("gregord", opts.HeartbeatInterval, opts.AliveThreshold, mstore)
+	statusGroup := srvup.New("gregord", opts.HeartbeatInterval, opts.AliveThreshold, mstore, log)
 
 	alive, err := statusGroup.Alive()
 	if err != nil {

--- a/rpc/server/alive_group.go
+++ b/rpc/server/alive_group.go
@@ -9,14 +9,15 @@ import (
 	"github.com/jonboulle/clockwork"
 	rpc "github.com/keybase/go-framed-msgpack-rpc"
 	"github.com/keybase/gregor/protocol/gregor1"
+	"github.com/keybase/gregor/srvup"
 )
 
 type aliveGroup struct {
-	group       map[string]*sibConn
+	group       map[srvup.NodeId]*sibConn
 	status      Aliver
 	authToken   gregor1.SessionToken
 	authTokenCh chan gregor1.SessionToken
-	selfHost    string
+	selfID      srvup.NodeId
 	clock       clockwork.Clock
 	done        chan struct{}
 	log         rpc.LogOutput
@@ -35,12 +36,14 @@ func waitToken(authTokenCh chan gregor1.SessionToken, log rpc.LogOutput) gregor1
 	}
 }
 
-func newAliveGroup(status Aliver, selfHost string, authTokenCh chan gregor1.SessionToken, timeout time.Duration, clock clockwork.Clock, done chan struct{}, log rpc.LogOutput) *aliveGroup {
+func newAliveGroup(status Aliver, selfID srvup.NodeId, authTokenCh chan gregor1.SessionToken,
+	timeout time.Duration, clock clockwork.Clock, done chan struct{}, log rpc.LogOutput) *aliveGroup {
+
 	authToken := waitToken(authTokenCh, log)
 	a := &aliveGroup{
-		group:       make(map[string]*sibConn),
+		group:       make(map[srvup.NodeId]*sibConn),
 		status:      status,
-		selfHost:    selfHost,
+		selfID:      selfID,
 		authToken:   authToken,
 		authTokenCh: authTokenCh,
 		clock:       clock,
@@ -59,15 +62,16 @@ func (a *aliveGroup) Publish(ctx context.Context, msg gregor1.Message) error {
 
 	perr := &pubErr{}
 
+	a.log.Debug("publishing message to %d peers", len(a.group))
 	var wg sync.WaitGroup
-	for host, conn := range a.group {
+	for id, conn := range a.group {
 		wg.Add(1)
 		go func() {
 			if err := conn.CallConsumePublishMessage(ctx, msg); err != nil {
-				a.log.Warning("host %q consumePubMessage error: %s", host, err)
-				perr.Add(host, err)
+				a.log.Warning("consumePubMessage error: id: %s host: %s err: %s", id, conn.hostname, err)
+				perr.Add(conn.hostname, err)
 			} else {
-				a.log.Debug("host %q consumePubMessage success", host)
+				a.log.Debug("consumePubMessage success: id: %s host: %s", id, conn.hostname)
 			}
 			wg.Done()
 		}()
@@ -118,12 +122,14 @@ func (a *aliveGroup) changed() (bool, error) {
 
 	a.RLock()
 	defer a.RUnlock()
+
+	// Check length for early out
 	if len(alive) != len(a.group) {
 		return true, nil
 	}
-
-	for _, host := range alive {
-		if _, ok := a.group[host]; !ok {
+	// Compare IDs to see if anything else is different
+	for _, node := range alive {
+		if _, ok := a.group[node.Id]; !ok {
 			return true, nil
 		}
 	}
@@ -135,38 +141,45 @@ func (a *aliveGroup) update() error {
 	if a.status == nil {
 		return nil
 	}
+
+	// Grab current list of alive servers
 	alive, err := a.status.Alive()
 	if err != nil {
 		return err
 	}
 
-	newgroup := make(map[string]*sibConn)
+	newgroup := make(map[srvup.NodeId]*sibConn)
 
+	// Build up new alive group by establishing connections to new gregors
 	a.RLock()
-	for _, host := range alive {
-		if host == a.selfHost {
+	for _, node := range alive {
+		// Don't connect to ourselves
+		if node.Id == a.selfID {
 			continue
 		}
-		if conn, ok := a.group[host]; ok {
-			newgroup[host] = conn
+		if conn, ok := a.group[node.Id]; ok {
+			newgroup[node.Id] = conn
 		} else {
-			newconn, err := NewSibConn(host, a.authToken, a.timeout, a.log)
+			newconn, err := NewSibConn(node.Hostname, a.authToken, a.timeout, a.log)
 			if err != nil {
-				a.log.Warning("error connecting to %q: %s", host, err)
+				a.log.Warning("error connecting to %q: %s", node.Hostname, err)
 			} else {
-				newgroup[host] = newconn
+				newgroup[node.Id] = newconn
 			}
 		}
 	}
 
-	for host, conn := range a.group {
-		if _, exists := newgroup[host]; !exists {
-			a.log.Debug("gregord on host %q no longer alive, shutting connection down", host)
+	// Shut down gregors that have disappeared
+	for id, conn := range a.group {
+		if _, exists := newgroup[id]; !exists {
+			a.log.Debug("gregord on host [ id: %s host: %q ] no longer alive, shutting connection down",
+				id, conn.hostname)
 			conn.Shutdown()
 		}
 	}
 	a.RUnlock()
 
+	// Commit the new group with a write lock
 	a.Lock()
 	a.group = newgroup
 	a.Unlock()

--- a/rpc/server/alive_group.go
+++ b/rpc/server/alive_group.go
@@ -68,10 +68,10 @@ func (a *aliveGroup) Publish(ctx context.Context, msg gregor1.Message) error {
 		wg.Add(1)
 		go func() {
 			if err := conn.CallConsumePublishMessage(ctx, msg); err != nil {
-				a.log.Warning("consumePubMessage error: id: %s host: %s err: %s", id, conn.hostname, err)
-				perr.Add(conn.hostname, err)
+				a.log.Warning("consumePubMessage error: id: %s addr: %s err: %s", id, conn.address, err)
+				perr.Add(conn.address, err)
 			} else {
-				a.log.Debug("consumePubMessage success: id: %s host: %s", id, conn.hostname)
+				a.log.Debug("consumePubMessage success: id: %s addr: %s", id, conn.address)
 			}
 			wg.Done()
 		}()
@@ -160,9 +160,9 @@ func (a *aliveGroup) update() error {
 		if conn, ok := a.group[node.Id]; ok {
 			newgroup[node.Id] = conn
 		} else {
-			newconn, err := NewSibConn(node.Hostname, a.authToken, a.timeout, a.log)
+			newconn, err := NewSibConn(node.Address, a.authToken, a.timeout, a.log)
 			if err != nil {
-				a.log.Warning("error connecting to %q: %s", node.Hostname, err)
+				a.log.Warning("error connecting to %q: %s", node.Address, err)
 			} else {
 				newgroup[node.Id] = newconn
 			}
@@ -172,8 +172,8 @@ func (a *aliveGroup) update() error {
 	// Shut down gregors that have disappeared
 	for id, conn := range a.group {
 		if _, exists := newgroup[id]; !exists {
-			a.log.Debug("gregord on host [ id: %s host: %q ] no longer alive, shutting connection down",
-				id, conn.hostname)
+			a.log.Debug("gregord on host [ id: %s addr: %q ] no longer alive, shutting connection down",
+				id, conn.address)
 			conn.Shutdown()
 		}
 	}

--- a/rpc/server/connection.go
+++ b/rpc/server/connection.go
@@ -128,7 +128,7 @@ func (c *connection) checkMessageAuth(ctx context.Context, m gregor1.Message) er
 
 func (c *connection) AuthenticateSessionToken(ctx context.Context, tok gregor1.SessionToken) (gregor1.AuthResult, error) {
 
-	c.log.Info("Authenticate: %+v", tok)
+	c.log.Debug("Authenticate: %+v", tok)
 	if tok == "" {
 		var UnauthenticatedSessionError = keybase1.Status{
 			Name: "BAD_SESSION",
@@ -161,7 +161,16 @@ func (c *connection) Sync(ctx context.Context, arg gregor1.SyncArg) (gregor1.Syn
 }
 
 func (c *connection) ConsumeMessage(ctx context.Context, m gregor1.Message) error {
-	c.log.Info("ConsumeMessage: %+v", m)
+
+	// Debugging
+	ibm := m.ToInBandMessage()
+	if ibm != nil {
+		c.log.Debug("ConsumeMessage: in-band message: msgID: %s Ctime: %s",
+			m.ToInBandMessage().Metadata().MsgID(), m.ToInBandMessage().Metadata().CTime())
+	} else {
+		c.log.Debug("ConsumeMessage: out-of-band message: uid: %s", m.ToOutOfBandMessage().UID())
+	}
+
 	if err := c.checkMessageAuth(ctx, m); err != nil {
 		return err
 	}
@@ -170,7 +179,16 @@ func (c *connection) ConsumeMessage(ctx context.Context, m gregor1.Message) erro
 }
 
 func (c *connection) ConsumePublishMessage(ctx context.Context, m gregor1.Message) error {
-	c.log.Info("ConsumePubMessage: %+v", m)
+
+	// Debugging
+	ibm := m.ToInBandMessage()
+	if ibm != nil {
+		c.log.Debug("ConsumeMessage: in-band message: msgID: %s Ctime: %s",
+			m.ToInBandMessage().Metadata().MsgID(), m.ToInBandMessage().Metadata().CTime())
+	} else {
+		c.log.Debug("ConsumeMessage: out-of-band message: uid: %s", m.ToOutOfBandMessage().UID())
+	}
+
 	if err := c.checkMessageAuth(ctx, m); err != nil {
 		c.close()
 		return err

--- a/rpc/server/publish_test.go
+++ b/rpc/server/publish_test.go
@@ -15,12 +15,13 @@ import (
 func TestPublish(t *testing.T) {
 	c := clockwork.NewFakeClock()
 	m := srvup.NewStorageMem(c)
+	log := rpc.SimpleLogOutput{}
 
 	incoming1 := newStorageStateMachine()
 	s1, l1, e1 := startTestServer(incoming1)
 	defer s1.Shutdown()
 	s1.superCh <- superToken
-	sg1 := srvup.New("gregord", 1*time.Second, 2*time.Second, m)
+	sg1 := srvup.New("gregord", 1*time.Second, 2*time.Second, m, log)
 	defer sg1.Shutdown()
 	sg1.HeartbeatLoop(l1.Addr().String())
 	s1.SetStatusGroup(sg1)
@@ -29,7 +30,7 @@ func TestPublish(t *testing.T) {
 	s2, l2, e2 := startTestServer(incoming2)
 	defer s2.Shutdown()
 	s2.superCh <- superToken
-	sg2 := srvup.New("gregord", 1*time.Second, 2*time.Second, m)
+	sg2 := srvup.New("gregord", 1*time.Second, 2*time.Second, m, log)
 	defer sg2.Shutdown()
 	sg2.HeartbeatLoop(l2.Addr().String())
 	s2.SetStatusGroup(sg2)
@@ -90,12 +91,13 @@ func TestPublish(t *testing.T) {
 func TestNodeIds(t *testing.T) {
 	c := clockwork.NewFakeClock()
 	m := srvup.NewStorageMem(c)
+	log := rpc.SimpleLogOutput{}
 
 	incoming1 := newStorageStateMachine()
 	s1, l1, _ := startTestServer(incoming1)
 	defer s1.Shutdown()
 	s1.superCh <- superToken
-	sg1 := srvup.New("gregord", 1*time.Second, 2*time.Second, m)
+	sg1 := srvup.New("gregord", 1*time.Second, 2*time.Second, m, log)
 	defer sg1.Shutdown()
 	sg1.HeartbeatLoop(l1.Addr().String())
 	s1.SetStatusGroup(sg1)
@@ -104,7 +106,7 @@ func TestNodeIds(t *testing.T) {
 	s2, l2, _ := startTestServer(incoming2)
 	defer s2.Shutdown()
 	s2.superCh <- superToken
-	sg2 := srvup.New("gregord", 1*time.Second, 2*time.Second, m)
+	sg2 := srvup.New("gregord", 1*time.Second, 2*time.Second, m, log)
 	defer sg2.Shutdown()
 	sg2.HeartbeatLoop(l2.Addr().String())
 	s2.SetStatusGroup(sg2)

--- a/rpc/server/sibconn.go
+++ b/rpc/server/sibconn.go
@@ -20,13 +20,13 @@ type sibConn struct {
 	log       rpc.LogOutput
 	conn      *rpc.Connection
 	logPrefix string
-	hostname  string
+	address   string
 }
 
-func NewSibConn(host string, authToken gregor1.SessionToken, timeout time.Duration,
+func NewSibConn(address string, authToken gregor1.SessionToken, timeout time.Duration,
 	log rpc.LogOutput) (*sibConn, error) {
 
-	uri, err := rpc.ParseFMPURI("fmprpc://" + host)
+	uri, err := rpc.ParseFMPURI("fmprpc://" + address)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func NewSibConn(host string, authToken gregor1.SessionToken, timeout time.Durati
 		timeout:   timeout,
 		log:       log,
 		logPrefix: fmt.Sprintf("[sibConn %s]", uri),
-		hostname:  host,
+		address:   address,
 	}
 
 	if err := s.connect(); err != nil {

--- a/rpc/server/sibconn.go
+++ b/rpc/server/sibconn.go
@@ -20,9 +20,12 @@ type sibConn struct {
 	log       rpc.LogOutput
 	conn      *rpc.Connection
 	logPrefix string
+	hostname  string
 }
 
-func NewSibConn(host string, authToken gregor1.SessionToken, timeout time.Duration, log rpc.LogOutput) (*sibConn, error) {
+func NewSibConn(host string, authToken gregor1.SessionToken, timeout time.Duration,
+	log rpc.LogOutput) (*sibConn, error) {
+
 	uri, err := rpc.ParseFMPURI("fmprpc://" + host)
 	if err != nil {
 		return nil, err
@@ -33,6 +36,7 @@ func NewSibConn(host string, authToken gregor1.SessionToken, timeout time.Durati
 		timeout:   timeout,
 		log:       log,
 		logPrefix: fmt.Sprintf("[sibConn %s]", uri),
+		hostname:  host,
 	}
 
 	if err := s.connect(); err != nil {

--- a/srvup/srvup.go
+++ b/srvup/srvup.go
@@ -113,6 +113,12 @@ func (s *Status) MyID() NodeId {
 // HeartbeatLoop runs a loop in a separate goroutine that sends a
 // heartbeat every s.pingInterval.
 func (s *Status) HeartbeatLoop(hostname string) {
+
+	// Put one out right away to make testing this easier
+	if err := s.heartbeat(hostname); err != nil {
+		s.log.Warning("heartbeat error: %s", err)
+	}
+
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()

--- a/srvup/srvup_test.go
+++ b/srvup/srvup_test.go
@@ -8,11 +8,12 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
+	rpc "github.com/keybase/go-framed-msgpack-rpc"
 )
 
 func setupMem(t *testing.T) (*Status, clockwork.FakeClock) {
 	c := clockwork.NewFakeClock()
-	s := New("gregord", 1*time.Second, 2*time.Second, NewStorageMem(c))
+	s := New("gregord", 1*time.Second, 2*time.Second, NewStorageMem(c), rpc.SimpleLogOutput{})
 	s.setClock(c)
 	return s, c
 }
@@ -21,7 +22,7 @@ func setupMysql(t *testing.T) (*Status, clockwork.FakeClock) {
 	c := clockwork.NewFakeClock()
 	m := connectMysql(t)
 	m.setClock(c)
-	s := New("gregord", 1*time.Second, 2*time.Second, m)
+	s := New("gregord", 1*time.Second, 2*time.Second, m, rpc.SimpleLogOutput{})
 	s.setClock(c)
 	return s, c
 }

--- a/srvup/storage_mem.go
+++ b/srvup/storage_mem.go
@@ -19,7 +19,7 @@ type StorageMem struct {
 
 type nodeRow struct {
 	heartbeat time.Time
-	hostname  string
+	address   string
 }
 
 type groupMap map[NodeId]nodeRow
@@ -39,7 +39,7 @@ func (m *StorageMem) UpdateServerStatus(group string, node NodeDesc) error {
 		g = make(groupMap)
 		m.groups[group] = g
 	}
-	g[node.Id] = nodeRow{heartbeat: m.clock.Now(), hostname: node.Hostname}
+	g[node.Id] = nodeRow{heartbeat: m.clock.Now(), address: node.Address}
 	return nil
 }
 
@@ -55,7 +55,7 @@ func (m *StorageMem) AliveServers(group string, threshold time.Duration) ([]Node
 		if m.clock.Now().Sub(row.heartbeat) >= threshold {
 			continue
 		}
-		alive = append(alive, NodeDesc{Id: id, Hostname: row.hostname})
+		alive = append(alive, NodeDesc{Id: id, Address: row.address})
 	}
 	return alive, nil
 }

--- a/srvup/storage_mysql.go
+++ b/srvup/storage_mysql.go
@@ -65,13 +65,13 @@ func (s *StorageMysql) setClock(c clockwork.Clock) {
 }
 
 // UpdateServerStatus implements Storage.UpdateServerStatus.
-func (s *StorageMysql) UpdateServerStatus(group, hostname string) error {
+func (s *StorageMysql) UpdateServerStatus(group string, node NodeDesc) error {
 	var err error
 	if s.update == nil {
 		if s.clock != nil {
-			s.update, err = s.db.Prepare("INSERT INTO server_status (groupname, hostname, hbtime, ctime) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE hbtime=?")
+			s.update, err = s.db.Prepare("INSERT INTO server_status (groupname, id, hostname, hbtime, ctime) VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE hbtime=?")
 		} else {
-			s.update, err = s.db.Prepare("INSERT INTO server_status (groupname, hostname, hbtime, ctime) VALUES (?, ?, NOW(), NOW()) ON DUPLICATE KEY UPDATE hbtime=NOW()")
+			s.update, err = s.db.Prepare("INSERT INTO server_status (groupname, id, hostname, hbtime, ctime) VALUES (?, ?, ?, NOW(), NOW()) ON DUPLICATE KEY UPDATE hbtime=NOW()")
 		}
 		if err != nil {
 			return err
@@ -80,21 +80,21 @@ func (s *StorageMysql) UpdateServerStatus(group, hostname string) error {
 
 	if s.clock != nil {
 		now := s.now()
-		_, err = s.update.Exec(group, hostname, now, now, now)
+		_, err = s.update.Exec(group, string(node.Id), node.Hostname, now, now, now)
 	} else {
-		_, err = s.update.Exec(group, hostname)
+		_, err = s.update.Exec(group, string(node.Id), node.Hostname)
 	}
 	return err
 }
 
 // AliveServers implements Storage.AliveServers.
-func (s *StorageMysql) AliveServers(group string, threshold time.Duration) ([]string, error) {
+func (s *StorageMysql) AliveServers(group string, threshold time.Duration) ([]NodeDesc, error) {
 	var err error
 	if s.alive == nil {
 		if s.clock != nil {
-			s.alive, err = s.db.Prepare("SELECT hostname FROM server_status WHERE groupname=? AND hbtime >= DATE_SUB(?, INTERVAL ? SECOND)")
+			s.alive, err = s.db.Prepare("SELECT id,hostname FROM server_status WHERE groupname=? AND hbtime >= DATE_SUB(?, INTERVAL ? SECOND)")
 		} else {
-			s.alive, err = s.db.Prepare("SELECT hostname FROM server_status WHERE groupname=? AND hbtime >= DATE_SUB(NOW(), INTERVAL ? SECOND)")
+			s.alive, err = s.db.Prepare("SELECT id,hostname FROM server_status WHERE groupname=? AND hbtime >= DATE_SUB(NOW(), INTERVAL ? SECOND)")
 		}
 		if err != nil {
 			return nil, err
@@ -112,20 +112,20 @@ func (s *StorageMysql) AliveServers(group string, threshold time.Duration) ([]st
 	}
 	defer rows.Close()
 
-	var hosts []string
+	var nodes []NodeDesc
 	for rows.Next() {
-		var h string
-		err = rows.Scan(&h)
+		var id, host string
+		err = rows.Scan(&id, &host)
 		if err != nil {
 			return nil, err
 		}
-		hosts = append(hosts, h)
+		nodes = append(nodes, NodeDesc{Id: NodeId(id), Hostname: host})
 	}
 	if err = rows.Err(); err != nil {
 		return nil, err
 	}
 
-	return hosts, nil
+	return nodes, nil
 }
 
 func (s *StorageMysql) cleanLoop() {
@@ -180,12 +180,13 @@ func (s *StorageMysql) resetSchema() error {
 
 var schema = []string{
 	`CREATE TABLE IF NOT EXISTS server_status (
-		groupname VARCHAR(32) NOT NULL,
-		hostname VARCHAR(128) NOT NULL,
-		hbtime DATETIME(6) NOT NULL,
-		ctime DATETIME NOT NULL,
-		PRIMARY KEY (groupname, hostname),
-		INDEX (groupname, hbtime)
+		groupname varchar(32) NOT NULL,
+		id varchar(64) NOT NULL,
+		hostname varchar(128) NOT NULL,
+		hbtime datetime(6) NOT NULL,
+		ctime datetime NOT NULL,
+		PRIMARY KEY (groupname,id),
+		KEY groupname (groupname,hbtime)
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8`,
 }
 

--- a/srvup/storage_mysql.go
+++ b/srvup/storage_mysql.go
@@ -69,9 +69,9 @@ func (s *StorageMysql) UpdateServerStatus(group string, node NodeDesc) error {
 	var err error
 	if s.update == nil {
 		if s.clock != nil {
-			s.update, err = s.db.Prepare("INSERT INTO server_status (groupname, id, hostname, hbtime, ctime) VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE hbtime=?")
+			s.update, err = s.db.Prepare("INSERT INTO server_status (groupname, id, address, hbtime, ctime) VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE hbtime=?")
 		} else {
-			s.update, err = s.db.Prepare("INSERT INTO server_status (groupname, id, hostname, hbtime, ctime) VALUES (?, ?, ?, NOW(), NOW()) ON DUPLICATE KEY UPDATE hbtime=NOW()")
+			s.update, err = s.db.Prepare("INSERT INTO server_status (groupname, id, address, hbtime, ctime) VALUES (?, ?, ?, NOW(), NOW()) ON DUPLICATE KEY UPDATE hbtime=NOW()")
 		}
 		if err != nil {
 			return err
@@ -80,9 +80,9 @@ func (s *StorageMysql) UpdateServerStatus(group string, node NodeDesc) error {
 
 	if s.clock != nil {
 		now := s.now()
-		_, err = s.update.Exec(group, string(node.Id), node.Hostname, now, now, now)
+		_, err = s.update.Exec(group, string(node.Id), node.Address, now, now, now)
 	} else {
-		_, err = s.update.Exec(group, string(node.Id), node.Hostname)
+		_, err = s.update.Exec(group, string(node.Id), node.Address)
 	}
 	return err
 }
@@ -92,9 +92,9 @@ func (s *StorageMysql) AliveServers(group string, threshold time.Duration) ([]No
 	var err error
 	if s.alive == nil {
 		if s.clock != nil {
-			s.alive, err = s.db.Prepare("SELECT id,hostname FROM server_status WHERE groupname=? AND hbtime >= DATE_SUB(?, INTERVAL ? SECOND)")
+			s.alive, err = s.db.Prepare("SELECT id,address FROM server_status WHERE groupname=? AND hbtime >= DATE_SUB(?, INTERVAL ? SECOND)")
 		} else {
-			s.alive, err = s.db.Prepare("SELECT id,hostname FROM server_status WHERE groupname=? AND hbtime >= DATE_SUB(NOW(), INTERVAL ? SECOND)")
+			s.alive, err = s.db.Prepare("SELECT id,address FROM server_status WHERE groupname=? AND hbtime >= DATE_SUB(NOW(), INTERVAL ? SECOND)")
 		}
 		if err != nil {
 			return nil, err
@@ -114,12 +114,12 @@ func (s *StorageMysql) AliveServers(group string, threshold time.Duration) ([]No
 
 	var nodes []NodeDesc
 	for rows.Next() {
-		var id, host string
-		err = rows.Scan(&id, &host)
+		var id, addr string
+		err = rows.Scan(&id, &addr)
 		if err != nil {
 			return nil, err
 		}
-		nodes = append(nodes, NodeDesc{Id: NodeId(id), Hostname: host})
+		nodes = append(nodes, NodeDesc{Id: NodeId(id), Address: addr})
 	}
 	if err = rows.Err(); err != nil {
 		return nil, err
@@ -181,8 +181,8 @@ func (s *StorageMysql) resetSchema() error {
 var schema = []string{
 	`CREATE TABLE IF NOT EXISTS server_status (
 		groupname varchar(32) NOT NULL,
-		id varchar(64) NOT NULL,
-		hostname varchar(128) NOT NULL,
+		id char(16) NOT NULL,
+		address varchar(128) NOT NULL,
 		hbtime datetime(6) NOT NULL,
 		ctime datetime NOT NULL,
 		PRIMARY KEY (groupname,id),


### PR DESCRIPTION
@maxtaco @patrickxb this patch introduces the use of IDs to uniquely identify gregord nodes, instead of hostname/port. The IDs are just a random base64 encoded string that is stored in the DB along with the host/port pair. 

In addition, the patch stops threading the context of the caller into gregord through to both broadcast and publish. Those operations really are not part of the client's request, and it seems more appropriate to attach them to the background context. Otherwise, you get weird results if the client hangs up early (i.e. you don't publish the consume, which doesn't seem right).

This is a big patch, so let me know what you think!