### PR TITLE
validate messages in ConsumeMessage CORE-3119

### DIFF
--- a/rpc/server/connection.go
+++ b/rpc/server/connection.go
@@ -167,6 +167,9 @@ func validateConsumeMessage(m gregor1.Message) error {
 	}
 	ibm := m.ToInBandMessage()
 	obm := m.ToOutOfBandMessage()
+	if ibm == nil && obm == nil {
+		return errfunc("unknown message type")
+	}
 	if ibm != nil {
 		upd := ibm.ToStateUpdateMessage()
 		if upd != nil {
@@ -180,25 +183,31 @@ func validateConsumeMessage(m gregor1.Message) error {
 					return errfunc("missing UID")
 				}
 			}
-			if upd.Creation() != nil {
-				if upd.Creation().Category() == nil {
-					return errfunc("missing category")
-				}
-				if upd.Creation().Body() == nil {
-					return errfunc("missing body")
-				}
-			} else if upd.Dismissal() != nil {
-				if upd.Dismissal().MsgIDsToDismiss() == nil {
-					return errfunc("missing msg IDs to dismiss")
-				}
-				if upd.Dismissal().RangesToDismiss() == nil {
-					return errfunc("missing ranges to dismiss")
-				}
-			} else {
+
+			if upd.Creation() == nil && upd.Dismissal() == nil {
 				return errfunc("unknown state update message type")
+			} else {
+				if upd.Creation() != nil {
+					if upd.Creation().Category() == nil {
+						return errfunc("missing category")
+					}
+					if upd.Creation().Body() == nil {
+						return errfunc("missing body")
+					}
+				}
+				if upd.Dismissal() != nil {
+					if upd.Dismissal().MsgIDsToDismiss() == nil {
+						return errfunc("missing msg IDs to dismiss")
+					}
+					if upd.Dismissal().RangesToDismiss() == nil {
+						return errfunc("missing ranges to dismiss")
+					}
+				}
 			}
 		}
-	} else if obm != nil {
+	}
+
+	if obm != nil {
 		if obm.UID() == nil {
 			return errfunc("missing UID")
 		}
@@ -208,8 +217,6 @@ func validateConsumeMessage(m gregor1.Message) error {
 		if obm.Body() == nil {
 			return errfunc("missing body")
 		}
-	} else {
-		return errfunc("unknown message type")
 	}
 
 	return nil

--- a/rpc/server/main.go
+++ b/rpc/server/main.go
@@ -335,6 +335,7 @@ func (s *Server) startSync(c context.Context, arg gregor1.SyncArg) (gregor1.Sync
 // and broadcasts it to the other clients. Like startSync, this function is called
 // from connection, and is on a different thread than Serve
 func (s *Server) runConsumeMessageMainSequence(c context.Context, m gregor1.Message) error {
+
 	res := s.storageConsumeMessage(m)
 	if res.err != nil {
 		return res.err

--- a/rpc/server/publish_test.go
+++ b/rpc/server/publish_test.go
@@ -44,7 +44,7 @@ func TestPublish(t *testing.T) {
 	<-e2.ConnCreated
 
 	// s1 consumes a message
-	m1 := newOOBMessage(goodUID, "sys", nil)
+	m1 := newOOBMessage(goodUID, "sys", []byte{})
 	if err := s1.runConsumeMessageMainSequence(context.TODO(), m1); err != nil {
 		t.Fatal(err)
 	}

--- a/rpc/server/server_test.go
+++ b/rpc/server/server_test.go
@@ -261,6 +261,10 @@ func newUpdateMessage(uid gregor1.UID) gregor1.Message {
 					Uid_:   uid,
 					MsgID_: []byte(msgid),
 				},
+				Creation_: &gregor1.Item{
+					Category_: "test",
+					Body_:     []byte(""),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
@maxtaco @oconnor663 This patch addresses CORE-3119 to make it harder for gregord to crash on bad input to its incoming RPCs. 

@oconnor663 you probably want to double check this won't break anything with the tracker popup window stuff, just to make sure it is passing all the required fields.