### PR TITLE
fix gregord authd deadlock CORE-3186

### DIFF
--- a/bin/gregord/main.go
+++ b/bin/gregord/main.go
@@ -54,7 +54,6 @@ func mainInner(log *bin.StandardLogger) (int, error) {
 
 		log.Debug("Setting authenticator")
 		srv.SetAuthenticator(sc)
-		srv.SetSuperTokenCh(sc.SuperTokenCh)
 	}
 
 	log.Debug("Connect to MySQL DB at %s", opts.MysqlDSN)

--- a/bin/gregord/mock_auth.go
+++ b/bin/gregord/mock_auth.go
@@ -55,6 +55,10 @@ func (m mockAuth) RevokeSessionIDs(_ context.Context, sessionIDs []gregor1.Sessi
 	return nil
 }
 
+func (m mockAuth) GetSuperToken() gregor1.SessionToken {
+	return ""
+}
+
 func (m mockAuth) CreateGregorSuperUserSessionToken(ctx context.Context) (gregor1.SessionToken, error) {
 	return "", errors.New("mockAuth super token not implemented")
 }

--- a/rpc/server/authd_handler.go
+++ b/rpc/server/authd_handler.go
@@ -47,6 +47,7 @@ func (a *authdHandler) GetSuperToken() gregor1.SessionToken {
 	if blank {
 		a.log.Debug("authd handler: GetSuperToken(): token blank: waiting...")
 		<-a.superCh
+		a.log.Debug("authd handler: GetSuperToken(): token blank: complete")
 	}
 
 	a.Lock()

--- a/rpc/server/authd_handler.go
+++ b/rpc/server/authd_handler.go
@@ -48,6 +48,8 @@ func (a *authdHandler) GetSuperToken() gregor1.SessionToken {
 		a.log.Debug("authd handler: GetSuperToken(): token blank: waiting...")
 		return <-a.superCh
 	} else {
+		a.Lock()
+		defer a.Unlock()
 		return a.superToken
 	}
 }

--- a/rpc/server/authd_handler.go
+++ b/rpc/server/authd_handler.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"errors"
 	"sync"
 	"time"
 
@@ -61,6 +62,9 @@ func (a *authdHandler) setSuperToken(cli gregor1.AuthInternalClient) error {
 	if err != nil {
 		a.log.Debug("setSuperToken: error creating super user session token: %s", err)
 		return err
+	} else if tok == "" {
+		a.log.Error("setSuperToken: got a blank token back with no error")
+		return errors.New("blank token from auth server")
 	} else {
 		a.log.Debug("setSuperToken: created super user session token")
 	}

--- a/rpc/server/publish_test.go
+++ b/rpc/server/publish_test.go
@@ -20,7 +20,6 @@ func TestPublish(t *testing.T) {
 	incoming1 := newStorageStateMachine()
 	s1, l1, e1 := startTestServer(incoming1)
 	defer s1.Shutdown()
-	s1.superCh <- superToken
 	sg1 := srvup.New("gregord", 1*time.Second, 2*time.Second, m, log)
 	defer sg1.Shutdown()
 	sg1.HeartbeatLoop("fmprpc://" + l1.Addr().String())
@@ -29,7 +28,6 @@ func TestPublish(t *testing.T) {
 	incoming2 := newStorageStateMachine()
 	s2, l2, e2 := startTestServer(incoming2)
 	defer s2.Shutdown()
-	s2.superCh <- superToken
 	sg2 := srvup.New("gregord", 1*time.Second, 2*time.Second, m, log)
 	defer sg2.Shutdown()
 	sg2.HeartbeatLoop("fmprpc://" + l2.Addr().String())
@@ -96,7 +94,6 @@ func TestNodeIds(t *testing.T) {
 	incoming1 := newStorageStateMachine()
 	s1, l1, _ := startTestServer(incoming1)
 	defer s1.Shutdown()
-	s1.superCh <- superToken
 	sg1 := srvup.New("gregord", 1*time.Second, 2*time.Second, m, log)
 	defer sg1.Shutdown()
 	sg1.HeartbeatLoop("fmprpc://" + l1.Addr().String())
@@ -105,13 +102,12 @@ func TestNodeIds(t *testing.T) {
 	incoming2 := newStorageStateMachine()
 	s2, l2, _ := startTestServer(incoming2)
 	defer s2.Shutdown()
-	s2.superCh <- superToken
 	sg2 := srvup.New("gregord", 1*time.Second, 2*time.Second, m, log)
 	defer sg2.Shutdown()
 	sg2.HeartbeatLoop("fmprpc://" + l2.Addr().String())
 	s2.SetStatusGroup(sg2)
 
-	ag := newAliveGroup(sg1, sg1.MyID(), s1.superCh, s1.publishTimeout, c, s1.closeCh,
+	ag := newAliveGroup(sg1, s1.auth, sg1.MyID(), s1.publishTimeout, c, s1.closeCh,
 		rpc.SimpleLogOutput{}, nil)
 	if len(ag.group) != 1 {
 		t.Fatalf("alive group is wrong size %d != 1", len(ag.group))

--- a/rpc/server/server_test.go
+++ b/rpc/server/server_test.go
@@ -48,6 +48,10 @@ func (m mockAuth) CreateGregorSuperUserSessionToken(_ context.Context) (gregor1.
 	return superToken, nil
 }
 
+func (m mockAuth) GetSuperToken() gregor1.SessionToken {
+	return superToken
+}
+
 func newStorageStateMachine() gregor.StateMachine {
 	var of gregor1.ObjFactory
 	return storage.NewMemEngine(of, clockwork.NewRealClock())
@@ -71,7 +75,7 @@ var (
 	superResult = gregor1.AuthResult{Uid: superUID, Sid: superSID}
 )
 
-var mockAuthenticator gregor1.AuthInterface = mockAuth{
+var mockAuthenticator Authenticator = mockAuth{
 	sessions: map[gregor1.SessionToken]gregor1.AuthResult{
 		goodToken:  goodResult,
 		evilToken:  evilResult,


### PR DESCRIPTION
@maxtaco @patrickxb a better attempt, this one removes the usage of superCh being passed throughout the modules, and instead keeps all the synchronization local to authd_handler.go