### PR TITLE
convert session cacher into using locks

### DIFF
--- a/rpc/server/session_cacher.go
+++ b/rpc/server/session_cacher.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"sync"
 	"time"
 
 	"github.com/jonboulle/clockwork"
@@ -11,11 +12,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-type authResp struct {
-	res    gregor1.AuthResult
-	expiry time.Time
-}
-
 type expirySt struct {
 	sid    gregor1.SessionID
 	expiry time.Time
@@ -23,33 +19,34 @@ type expirySt struct {
 
 // SessionCacher implements gregor1.AuthInterface with a cache of authenticated sessions.
 type SessionCacher struct {
-	parent          gregor1.AuthInterface
-	cl              clockwork.Clock
-	timeout         time.Duration
-	sessions        map[gregor1.SessionToken]*gregor1.AuthResult
-	sessionIDs      map[gregor1.SessionID]gregor1.SessionToken
-	reqCh           chan request
-	statsShutdownCh chan struct{}
-	expiryQueue     []expirySt
-	authdHandler    *authdHandler
-	stats           stats.Registry
+	sync.RWMutex
+	parent       gregor1.AuthInterface
+	cl           clockwork.Clock
+	timeout      time.Duration
+	sessions     map[gregor1.SessionToken]*gregor1.AuthResult
+	sessionIDs   map[gregor1.SessionID]gregor1.SessionToken
+	shutdownCh   chan struct{}
+	expiryQueue  []expirySt
+	authdHandler *authdHandler
+	stats        stats.Registry
 }
 
 // NewSessionCacher creates a new AuthInterface that caches sessions for the given timeout.
 func NewSessionCacher(a gregor1.AuthInterface, stats stats.Registry, cl clockwork.Clock,
 	timeout time.Duration) *SessionCacher {
 	sc := &SessionCacher{
-		parent:          a,
-		cl:              cl,
-		timeout:         timeout,
-		sessions:        make(map[gregor1.SessionToken]*gregor1.AuthResult),
-		sessionIDs:      make(map[gregor1.SessionID]gregor1.SessionToken),
-		reqCh:           make(chan request),
-		statsShutdownCh: make(chan struct{}),
-		stats:           stats.SetPrefix("session_cacher"),
+		parent:     a,
+		cl:         cl,
+		timeout:    timeout,
+		sessions:   make(map[gregor1.SessionToken]*gregor1.AuthResult),
+		sessionIDs: make(map[gregor1.SessionID]gregor1.SessionToken),
+		shutdownCh: make(chan struct{}),
+		stats:      stats.SetPrefix("session_cacher"),
 	}
-	go sc.requestHandler()
+
 	go sc.updateStatsLoop()
+	go sc.clearExpiryQueueLoop()
+
 	return sc
 }
 
@@ -79,7 +76,7 @@ func (sc *SessionCacher) updateStats() {
 func (sc *SessionCacher) updateStatsLoop() {
 	for {
 		select {
-		case <-sc.statsShutdownCh:
+		case <-sc.shutdownCh:
 			return
 		case <-time.After(time.Second):
 			sc.updateStats()
@@ -87,20 +84,9 @@ func (sc *SessionCacher) updateStatsLoop() {
 	}
 }
 
-type request interface{}
-
-type setResReq struct {
-	tok gregor1.SessionToken
-	res *gregor1.AuthResult
-}
-
 func (sc *SessionCacher) setRes(tok gregor1.SessionToken, res *gregor1.AuthResult) {
 	sc.sessions[tok] = res
 	sc.sessionIDs[res.Sid] = tok
-}
-
-type deleteSIDReq struct {
-	sid gregor1.SessionID
 }
 
 func (sc *SessionCacher) deleteSID(sid gregor1.SessionID) {
@@ -112,21 +98,22 @@ func (sc *SessionCacher) deleteSID(sid gregor1.SessionID) {
 	}
 }
 
-type readTokReq struct {
-	tok  gregor1.SessionToken
-	resp chan *gregor1.AuthResult
-}
-
-type sizeReq struct {
-	resp chan int
-}
-
-type authReq struct {
-	resp chan gregor1.AuthInterface
+func (sc *SessionCacher) clearExpiryQueueLoop() {
+	for {
+		select {
+		case <-sc.cl.After(10 * time.Second):
+			sc.clearExpiryQueue()
+		case <-sc.shutdownCh:
+			return
+		}
+	}
 }
 
 // clearExpiryQueue removes all currently expired sessions.
 func (sc *SessionCacher) clearExpiryQueue() {
+	sc.Lock()
+	defer sc.Unlock()
+
 	now := sc.cl.Now()
 	for _, e := range sc.expiryQueue {
 		if now.Before(e.expiry) {
@@ -138,32 +125,9 @@ func (sc *SessionCacher) clearExpiryQueue() {
 	}
 }
 
-// requestHandler runs in a single goroutine, handling all access requests and
-// periodic expiry of sessions.
-func (sc *SessionCacher) requestHandler() {
-	for req := range sc.reqCh {
-		sc.clearExpiryQueue()
-		switch req := req.(type) {
-		case readTokReq:
-			req.resp <- sc.sessions[req.tok]
-		case setResReq:
-			expiry := sc.cl.Now().Add(sc.timeout)
-			sc.expiryQueue = append(sc.expiryQueue, expirySt{req.res.Sid, expiry})
-			sc.setRes(req.tok, req.res)
-		case deleteSIDReq:
-			sc.deleteSID(req.sid)
-		case sizeReq:
-			req.resp <- len(sc.sessions)
-		case authReq:
-			req.resp <- sc.parent
-		}
-	}
-}
-
 // Close allows the SessionCacher to be garbage collected.
 func (sc *SessionCacher) Close() {
-	close(sc.reqCh)
-	close(sc.statsShutdownCh)
+	close(sc.shutdownCh)
 	if sc.authdHandler != nil {
 		sc.authdHandler.Close()
 	}
@@ -171,32 +135,35 @@ func (sc *SessionCacher) Close() {
 
 // Size returns the number of sessions currently in the cache.
 func (sc *SessionCacher) Size() int {
-	respCh := make(chan int)
-	sc.reqCh <- sizeReq{respCh}
-	return <-respCh
+	sc.RLock()
+	defer sc.RUnlock()
+	return len(sc.sessions)
 }
 
 // AuthenticateSessionToken authenticates a given session token, first against
 // the cache and the, if that fails, against the parent AuthInterface.
 func (sc *SessionCacher) AuthenticateSessionToken(ctx context.Context, tok gregor1.SessionToken) (res gregor1.AuthResult, err error) {
 
-	respCh := make(chan *gregor1.AuthResult)
-
 	// Fire off request for a cached session
 	sc.stats.Count("AuthenticateSessionToken")
-	sc.reqCh <- readTokReq{tok, respCh}
+	sc.RLock()
+	pres := sc.sessions[tok]
+	sc.RUnlock()
 
-	// Receive the response and return it if we hit the cache
-	resp := <-respCh
-	if resp != nil {
+	// Return res if we hit the cache
+	if pres != nil {
+		res = *pres
 		sc.stats.Count("AuthenticateSessionToken - cache hit")
-		res = *resp
 		return
 	}
 
 	// Call out to authd and store the result
 	if res, err = sc.parent.AuthenticateSessionToken(ctx, tok); err == nil {
-		sc.reqCh <- setResReq{tok, &res}
+		sc.Lock()
+		expiry := sc.cl.Now().Add(sc.timeout)
+		sc.expiryQueue = append(sc.expiryQueue, expirySt{res.Sid, expiry})
+		sc.setRes(tok, &res)
+		sc.Unlock()
 	}
 
 	return
@@ -204,12 +171,10 @@ func (sc *SessionCacher) AuthenticateSessionToken(ctx context.Context, tok grego
 
 // RevokeSessionIDs revokes the given session IDs in the cache.
 func (sc *SessionCacher) RevokeSessionIDs(ctx context.Context, sessionIDs []gregor1.SessionID) error {
+	sc.Lock()
+	defer sc.Unlock()
 	for _, sid := range sessionIDs {
-		select {
-		case sc.reqCh <- deleteSIDReq{sid}:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+		sc.deleteSID(sid)
 	}
 	return nil
 }

--- a/rpc/server/session_cacher.go
+++ b/rpc/server/session_cacher.go
@@ -91,9 +91,7 @@ func (sc *SessionCacher) setRes(tok gregor1.SessionToken, res *gregor1.AuthResul
 
 func (sc *SessionCacher) deleteSID(sid gregor1.SessionID) {
 	if tok, ok := sc.sessionIDs[sid]; ok {
-		if _, ok := sc.sessions[tok]; ok {
-			delete(sc.sessions, sc.sessionIDs[sid])
-		}
+		delete(sc.sessions, tok)
 		delete(sc.sessionIDs, sid)
 	}
 }
@@ -120,7 +118,7 @@ func (sc *SessionCacher) clearExpiryQueue() {
 			return
 		}
 
-		sc.deleteSID(sc.expiryQueue[0].sid)
+		sc.deleteSID(e.sid)
 		sc.expiryQueue = sc.expiryQueue[1:]
 	}
 }

--- a/rpc/server/session_cacher_test.go
+++ b/rpc/server/session_cacher_test.go
@@ -37,7 +37,7 @@ func TestSessionCacher(t *testing.T) {
 	}
 	checkBad(t, a, badToken)
 	checkGood(t, a, goodToken, goodUID)
-	d := 100 * time.Millisecond
+	d := 2 * time.Minute
 	fc := clockwork.NewFakeClock()
 	sc := NewSessionCacher(a, stats.DummyRegistry{}, fc, d)
 	defer sc.Close()
@@ -58,7 +58,9 @@ func TestSessionCacher(t *testing.T) {
 	assertCacheSize(t, sc, 1)
 
 	// Advance past timeout, cached results gone
+	fc.BlockUntil(1)
 	fc.Advance(d)
+	fc.BlockUntil(1)
 	assertCacheSize(t, sc, 0)
 	checkBad(t, sc, goodToken)
 }


### PR DESCRIPTION
@maxtaco not a priority, but this converts `SessionCacher` to using locks instead of the channel loop, it's just much clearer this way.