### PR TITLE
refactor UID server sychronization CORE-3237

### DIFF
--- a/bin/gregord/flow_test.go
+++ b/bin/gregord/flow_test.go
@@ -206,7 +206,7 @@ func startTestGregord(t *testing.T, db *sql.DB, auth *mockAuth) (net.Addr, *test
 		StorageHandlers:  10,
 		StorageQueueSize: 10000,
 	}
-	srv := server.NewServer(rpc.SimpleLogOutput{}, stats.DummyRegistry{}, opts)
+	srv := server.NewServer(rpc.SimpleLogOutput{}, clockwork.NewFakeClock(), stats.DummyRegistry{}, opts)
 	srv.SetAuthenticator(auth)
 	e := test.NewEvents()
 	srv.SetEventHandler(e)
@@ -220,7 +220,6 @@ func startTestGregord(t *testing.T, db *sql.DB, auth *mockAuth) (net.Addr, *test
 	sm, clock := storage.NewTestMySQLEngine(db, gregor1.ObjFactory{})
 	srv.SetStorageStateMachine(sm)
 
-	go srv.Serve()
 	go func() {
 		maybeSleep()
 		if err := ms.listenAndServe(); err != nil {

--- a/bin/gregord/main.go
+++ b/bin/gregord/main.go
@@ -49,7 +49,7 @@ func mainInner(log *bin.StandardLogger) (int, error) {
 	stats := setupStats(opts, log)
 	defer stats.Shutdown()
 
-	srv := server.NewServer(log, stats, srvopts)
+	srv := server.NewServer(log, clockwork.NewRealClock(), stats, srvopts)
 
 	if opts.MockAuth {
 		srv.SetAuthenticator(newMockAuth())
@@ -84,7 +84,6 @@ func mainInner(log *bin.StandardLogger) (int, error) {
 
 	sm := storage.NewMySQLEngine(db, gregor1.ObjFactory{})
 	srv.SetStorageStateMachine(sm)
-	go srv.Serve()
 
 	log.Debug("Calling mainServer.listenAndServe()")
 	err = newMainServer(opts, srv).listenAndServe()

--- a/rpc/server/main.go
+++ b/rpc/server/main.go
@@ -228,16 +228,18 @@ func (s *Server) waitOnUIDServer(usrv *perUIDServer) {
 		select {
 		case <-usrv.ShouldShutdown():
 			s.Lock()
-			if usrv.ConfirmShutdown() {
+			confirmed := usrv.ConfirmShutdown()
+			if confirmed {
 				delete(s.users, s.uidKey(usrv.uid))
-				s.Unlock()
+			}
+			s.Unlock()
+			if confirmed {
 				usrv.Shutdown()
 				if s.events != nil {
 					s.events.UIDServerDestroyed(usrv.uid)
 				}
 				return
 			}
-			s.Unlock()
 		case <-s.shutdownCh:
 			return
 		}

--- a/rpc/server/main.go
+++ b/rpc/server/main.go
@@ -195,7 +195,7 @@ func (s *Server) updateServerValueStatsLoop() {
 		select {
 		case <-s.shutdownCh:
 			return
-		case <-time.After(time.Second):
+		case <-s.clock.After(time.Second):
 			s.updateServerValueStats()
 		}
 	}

--- a/rpc/server/publish_test.go
+++ b/rpc/server/publish_test.go
@@ -18,7 +18,7 @@ func TestPublish(t *testing.T) {
 	log := rpc.SimpleLogOutput{}
 
 	incoming1 := newStorageStateMachine()
-	s1, l1, e1 := startTestServer(incoming1)
+	s1, l1, e1, _ := startTestServer(incoming1)
 	defer s1.Shutdown()
 	sg1 := srvup.New("gregord", 1*time.Second, 2*time.Second, m, log)
 	defer sg1.Shutdown()
@@ -26,7 +26,7 @@ func TestPublish(t *testing.T) {
 	s1.SetStatusGroup(sg1)
 
 	incoming2 := newStorageStateMachine()
-	s2, l2, e2 := startTestServer(incoming2)
+	s2, l2, e2, _ := startTestServer(incoming2)
 	defer s2.Shutdown()
 	sg2 := srvup.New("gregord", 1*time.Second, 2*time.Second, m, log)
 	defer sg2.Shutdown()
@@ -92,7 +92,7 @@ func TestNodeIds(t *testing.T) {
 	log := rpc.SimpleLogOutput{}
 
 	incoming1 := newStorageStateMachine()
-	s1, l1, _ := startTestServer(incoming1)
+	s1, l1, _, _ := startTestServer(incoming1)
 	defer s1.Shutdown()
 	sg1 := srvup.New("gregord", 1*time.Second, 2*time.Second, m, log)
 	defer sg1.Shutdown()
@@ -100,14 +100,14 @@ func TestNodeIds(t *testing.T) {
 	s1.SetStatusGroup(sg1)
 
 	incoming2 := newStorageStateMachine()
-	s2, l2, _ := startTestServer(incoming2)
+	s2, l2, _, _ := startTestServer(incoming2)
 	defer s2.Shutdown()
 	sg2 := srvup.New("gregord", 1*time.Second, 2*time.Second, m, log)
 	defer sg2.Shutdown()
 	sg2.HeartbeatLoop("fmprpc://" + l2.Addr().String())
 	s2.SetStatusGroup(sg2)
 
-	ag := newAliveGroup(sg1, s1.auth, sg1.MyID(), s1.publishTimeout, c, s1.closeCh,
+	ag := newAliveGroup(sg1, s1.auth, sg1.MyID(), s1.publishTimeout, c, s1.shutdownCh,
 		rpc.SimpleLogOutput{}, nil)
 	if len(ag.group) != 1 {
 		t.Fatalf("alive group is wrong size %d != 1", len(ag.group))

--- a/rpc/server/server_test.go
+++ b/rpc/server/server_test.go
@@ -450,7 +450,7 @@ func TestBroadcastTimeout(t *testing.T) {
 }
 
 func TestCloseOne(t *testing.T) {
-	s, l, ev, cl := startTestServer(nil)
+	s, l, ev, _ := startTestServer(nil)
 	defer l.Close()
 	defer s.Shutdown()
 
@@ -482,7 +482,6 @@ func TestCloseOne(t *testing.T) {
 	}
 
 	// wait for the perUID server to be shutdown
-	cl.Advance(time.Minute)
 	<-ev.PerUIDDestroyed
 
 	// and the user server should be deleted:
@@ -541,7 +540,7 @@ func TestCloseConnect(t *testing.T) {
 }
 
 func TestCloseConnect2(t *testing.T) {
-	s, l, ev, cl := startTestServer(nil)
+	s, l, ev, _ := startTestServer(nil)
 	defer l.Close()
 	defer s.Shutdown()
 
@@ -563,7 +562,6 @@ func TestCloseConnect2(t *testing.T) {
 		t.Logf("broadcast error: %s", err)
 	}
 
-	cl.Advance(time.Minute)
 	<-ev.PerUIDDestroyed
 
 	c2 := newClient(l.Addr())


### PR DESCRIPTION
@maxtaco @patrickxb 

The major change here is to use locks to synchronize access within both `rpc.server.Server` and `rpc.server.perUIDServer`. The net result is the amount of channel communication between them for managing new connections and such has been greatly reduced. I think this makes the code easier to follow, and less bug prone (although both files now have comments indicating which functions need locks to be called...)

Anyway, this passes `go test -race` and seems to work, but the question is do we like it more. Let me know!